### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "git://github.com/fb55/entities.git"
   },
-  "license": "BSD-like",
+  "license": "BSD-2-Clause",
   "jshintConfig": {
     "eqeqeq": true,
     "freeze": true,


### PR DESCRIPTION
Fixed to comply with NPM package.json rules.
https://docs.npmjs.com/files/package.json#license

The `LICENSE` file is essentially the same as the SPDX [BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) license.