### PR TITLE
function no replace non-ascii

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,10 @@ exports.encode = function(data, level) {
 };
 
 exports.encodeXML = encode.XML;
+exports.encodeXMLKeepNonAscii = encode.XMLKeepNonAscii;
 
 exports.encodeHTML4 = exports.encodeHTML5 = exports.encodeHTML = encode.HTML;
+exports.encodeHTMLKeepNonAscii = encode.HTMLKeepNonAscii;
 
 exports.decodeXML = exports.decodeXMLStrict = decode.XML;
 

--- a/lib/encode.js
+++ b/lib/encode.js
@@ -2,11 +2,13 @@ var inverseXML = getInverseObj(require("../maps/xml.json")),
     xmlReplacer = getInverseReplacer(inverseXML);
 
 exports.XML = getInverse(inverseXML, xmlReplacer);
+exports.XMLKeepNonAscii = getInverseWithoutNonAscii(inverseXML, xmlReplacer);
 
 var inverseHTML = getInverseObj(require("../maps/entities.json")),
     htmlReplacer = getInverseReplacer(inverseHTML);
 
 exports.HTML = getInverse(inverseHTML, htmlReplacer);
+exports.HTMLKeepNonAscii = getInverseWithoutNonAscii(inverseHTML, htmlReplacer);
 
 function getInverseObj(obj) {
     return Object.keys(obj)
@@ -57,6 +59,17 @@ function astralReplacer(c) {
     return "&#x" + codePoint.toString(16).toUpperCase() + ";";
 }
 
+function getInverseWithoutNonAscii(inverse, re) {
+    function func(name) {
+        return inverse[name];
+    }
+
+    return function(data) {
+        return data
+            .replace(re, func)
+            .replace(re_astralSymbols, astralReplacer);
+    };
+}
 function getInverse(inverse, re) {
     function func(name) {
         return inverse[name];

--- a/test/test.js
+++ b/test/test.js
@@ -169,7 +169,7 @@ describe("Escape", function() {
     });
 });
 
-descripbe("Keep non ascii", function() {
+describe("Keep non ascii", function() {
     var input = "#> 你好，'世界' & ÿ ü >",
         html = "&num;&gt; 你好，&apos;世界&apos; &amp; &yuml; &uuml; &gt;",
         xml = "#&gt; 你好，&apos;世界&apos; &amp; ÿ ü &gt;";

--- a/test/test.js
+++ b/test/test.js
@@ -7,7 +7,7 @@ describe("Encode->decode test", function() {
         {
             input: "asdf & ÿ ü '",
             xml: "asdf &amp; &#xFF; &#xFC; &apos;",
-            html: "asdf &amp; &yuml; &uuml; &apos;"
+            html: "asdf &amp; &yuml; &uuml; &apos;",
         },
         {
             input: "&#38;",
@@ -166,5 +166,17 @@ describe("Escape", function() {
             var c = String.fromCharCode(i);
             assert.equal(entities.decodeXML(entities.escape(c)), c);
         }
+    });
+});
+
+descripbe("Keep non ascii", function() {
+    var input = "#> 你好，'世界' & ÿ ü >",
+        html = "&num;&gt; 你好，&apos;世界&apos; &amp; &yuml; &uuml; &gt;",
+        xml = "#&gt; 你好，&apos;世界&apos; &amp; ÿ ü &gt;";
+    it("should keep non ASCII when encode with HTMLKeepNonAscii", function() {
+        assert.equal(entities.encodeHTMLKeepNonAscii(input), html);
+    });
+    it("should keep non ASCII when encode with XMLKeepNonAscii", function() {
+        assert.equal(entities.encodeXMLKeepNonAscii(input), xml);
     });
 });


### PR DESCRIPTION
provide another method encode only necessary `exports.XMLKeepNonAscii` and `exports.HTMLKeepNonAscii` .
i am from cheerio.