### PR TITLE
Fix benchmark, update html-entities test to v2.0. Fixes #377.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,10 +29,10 @@ This is how `entities` compares to other libraries on a very basic benchmark (se
 
 | Library        | `decode` performance | `encode` performance | Bundle size                                                                |
 | -------------- | -------------------- | -------------------- | -------------------------------------------------------------------------- |
-| entities       | 10.809s              | 17.683s              | ![npm bundle size](https://img.shields.io/bundlephobia/min/entities)       |
-| html-entities  | 14.029s              | 22.670s              | ![npm bundle size](https://img.shields.io/bundlephobia/min/html-entities)  |
-| he             | 16.163s              | 44.010s              | ![npm bundle size](https://img.shields.io/bundlephobia/min/he)             |
-| parse-entities | 28.507s              | N/A                  | ![npm bundle size](https://img.shields.io/bundlephobia/min/parse-entities) |
+| entities       | 8.326s               | 9.584s               | ![npm bundle size](https://img.shields.io/bundlephobia/min/entities)       |
+| html-entities  | 6.575s               | 8.031s               | ![npm bundle size](https://img.shields.io/bundlephobia/min/html-entities)  |
+| he             | 11.059s              | 20.820s              | ![npm bundle size](https://img.shields.io/bundlephobia/min/he)             |
+| parse-entities | 24.082s              | N/A                  | ![npm bundle size](https://img.shields.io/bundlephobia/min/parse-entities) |
 
 ---
 

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -6,14 +6,26 @@ import * as htmlEntities from "html-entities";
 
 const RUNS = 1e7;
 
+const htmlEntitiesHtml5EncodeOptions: htmlEntities.EncodeOptions = {
+    level: 'html5',
+    mode: 'nonAsciiPrintable'
+};
+
+const heEscapeOptions = {useNamedReferences: true};
+
 const encoders: [string, (str: string) => string][] = [
     ["entities", (str: string) => entities.encodeHTML(str)],
-    ["he", (str: string) => he.encode(str)],
+    ["he", (str: string) => he.encode(str, heEscapeOptions)],
     [
         "html-entities",
-        (str: string) => htmlEntities.AllHtmlEntities.encode(str),
+        (str: string) => htmlEntities.encode(str, htmlEntitiesHtml5EncodeOptions),
     ],
 ];
+
+const htmlEntitiesHtml5DecodeOptions: htmlEntities.DecodeOptions = {
+    level: 'html5',
+    scope: 'body'
+};
 
 const decoders: [string, (str: string) => string][] = [
     ["entities", (str: string) => entities.decodeHTML(str)],
@@ -21,9 +33,14 @@ const decoders: [string, (str: string) => string][] = [
     ["parse-entities", (str: string) => parseEntities(str)],
     [
         "html-entities",
-        (str: string) => htmlEntities.AllHtmlEntities.decode(str),
+        (str: string) => htmlEntities.decode(str, htmlEntitiesHtml5DecodeOptions),
     ],
 ];
+
+const htmlEntitiesXmlEncodeOptions: htmlEntities.EncodeOptions = {
+    level: 'html5',
+    mode: 'specialChars'
+};
 
 /*
  * Note: Not shown on the README, as `entities` differs in behavior from other libraries.
@@ -33,7 +50,10 @@ const escapers: [string, (str: string) => string][] = [
     ["entities", (str: string) => entities.encodeXML(str)],
     ["he", (str: string) => he.escape(str)],
     // Html-entities cannot escape, so we use its simplest mode.
-    ["html-entities", (str: string) => htmlEntities.XmlEntities.encode(str)],
+    [
+        "html-entities",
+        (str: string) => htmlEntities.encode(str, htmlEntitiesXmlEncodeOptions)
+    ],
 ];
 
 const textToDecode = `This is a simple text &uuml;ber &#x${"?"

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -7,24 +7,25 @@ import * as htmlEntities from "html-entities";
 const RUNS = 1e7;
 
 const htmlEntitiesHtml5EncodeOptions: htmlEntities.EncodeOptions = {
-    level: 'html5',
-    mode: 'nonAsciiPrintable'
+    level: "html5",
+    mode: "nonAsciiPrintable",
 };
 
-const heEscapeOptions = {useNamedReferences: true};
+const heEscapeOptions = { useNamedReferences: true };
 
 const encoders: [string, (str: string) => string][] = [
     ["entities", (str: string) => entities.encodeHTML(str)],
     ["he", (str: string) => he.encode(str, heEscapeOptions)],
     [
         "html-entities",
-        (str: string) => htmlEntities.encode(str, htmlEntitiesHtml5EncodeOptions),
+        (str: string) =>
+            htmlEntities.encode(str, htmlEntitiesHtml5EncodeOptions),
     ],
 ];
 
 const htmlEntitiesHtml5DecodeOptions: htmlEntities.DecodeOptions = {
-    level: 'html5',
-    scope: 'body'
+    level: "html5",
+    scope: "body",
 };
 
 const decoders: [string, (str: string) => string][] = [
@@ -33,13 +34,14 @@ const decoders: [string, (str: string) => string][] = [
     ["parse-entities", (str: string) => parseEntities(str)],
     [
         "html-entities",
-        (str: string) => htmlEntities.decode(str, htmlEntitiesHtml5DecodeOptions),
+        (str: string) =>
+            htmlEntities.decode(str, htmlEntitiesHtml5DecodeOptions),
     ],
 ];
 
 const htmlEntitiesXmlEncodeOptions: htmlEntities.EncodeOptions = {
-    level: 'html5',
-    mode: 'specialChars'
+    level: "html5",
+    mode: "specialChars",
 };
 
 /*
@@ -52,7 +54,7 @@ const escapers: [string, (str: string) => string][] = [
     // Html-entities cannot escape, so we use its simplest mode.
     [
         "html-entities",
-        (str: string) => htmlEntities.encode(str, htmlEntitiesXmlEncodeOptions)
+        (str: string) => htmlEntities.encode(str, htmlEntitiesXmlEncodeOptions),
     ],
 ];
 


### PR DESCRIPTION
1. Updates test code for `html-entities` to version 2.
2. Passes options to `he.encode()` to enable named references.
3. Updates README with benchmark results.