### PR TITLE
refactor(decode): Use a trie for 50% faster decoding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,10 +23,7 @@
         "curly": [2, "multi-line"],
         "no-else-return": 2,
 
-        "node/no-unsupported-features/es-syntax": [
-            2,
-            { "ignores": ["modules"] }
-        ]
+        "node/no-unsupported-features/es-syntax": 0
     },
     "overrides": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
                 "ts-jest": "^27.0.1",
                 "typescript": "^4.0.2"
             },
+            "engines": {
+                "node": ">=0.12"
+            },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
             }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "files": [
         "lib/**/*"
     ],
+    "engines": {
+        "node": ">=0.12"
+    },
     "devDependencies": {
         "@types/jest": "^26.0.0",
         "@types/node": "^15.0.0",

--- a/src/decode_codepoint.ts
+++ b/src/decode_codepoint.ts
@@ -3,7 +3,7 @@ import decodeMap from "./maps/decode.json";
 // Adapted from https://github.com/mathiasbynens/he/blob/master/src/he.js#L94-L119
 
 const fromCodePoint =
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, node/no-unsupported-features/es-builtins
     String.fromCodePoint ||
     function (codePoint: number): string {
         let output = "";

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -37,7 +37,7 @@ export const encodeHTML = getInverse(inverseHTML, htmlReplacer);
  */
 export const encodeNonAsciiHTML = getASCIIEncoder(inverseHTML);
 
-import { MapType } from "./decode";
+type MapType = Record<string, string>;
 
 function getInverseObj(obj: MapType): MapType {
     return Object.keys(obj)


### PR DESCRIPTION
This uses JS' native `Map` object, which requires Node >= 0.12.