### PR TITLE
refactor(encode): Use trie for encoding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,6 +47,7 @@
                 "@typescript-eslint/member-ordering": 0,
                 "@typescript-eslint/explicit-function-return-type": 0,
                 "@typescript-eslint/no-unused-vars": 0,
+                "@typescript-eslint/no-non-null-assertion": 0,
                 "@typescript-eslint/no-use-before-define": [
                     2,
                     { "functions": false }

--- a/src/encode-trie.ts
+++ b/src/encode-trie.ts
@@ -1,0 +1,79 @@
+import htmlMap from "./maps/entities.json";
+
+// For compatibility with node < 4, we wrap `codePointAt`
+export const getCodePoint =
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    String.prototype.codePointAt != null
+        ? (str: string, index: number): number => str.codePointAt(index)!
+        : // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
+          (c: string, index: number): number =>
+              (c.charCodeAt(index) & 0xd800) === 0xd800
+                  ? (c.charCodeAt(index) - 0xd800) * 0x400 +
+                    c.charCodeAt(index + 1) -
+                    0xdc00 +
+                    0x10000
+                  : c.charCodeAt(index);
+
+const htmlTrie = getTrie(htmlMap);
+
+export function encodeHTMLTrieRe(regExp: RegExp, str: string): string {
+    let ret = "";
+    let lastIdx = 0;
+    let match;
+
+    while ((match = regExp.exec(str)) !== null) {
+        const i = match.index;
+        const char = str.charCodeAt(i);
+        const next = htmlTrie.get(char);
+
+        if (next) {
+            if (next.next != null && i + 1 < str.length) {
+                const value = next.next.get(str.charCodeAt(i + 1))?.value;
+                if (value != null) {
+                    ret += str.substring(lastIdx, i) + value;
+                    regExp.lastIndex += 1;
+                    lastIdx = i + 2;
+                    continue;
+                }
+            }
+
+            ret += str.substring(lastIdx, i) + next.value;
+            lastIdx = i + 1;
+        } else {
+            ret += `${str.substring(lastIdx, i)}&#x${getCodePoint(
+                str,
+                i
+            ).toString(16)};`;
+            // Increase by 1 if we have a surrogate pair
+            lastIdx = regExp.lastIndex += Number((char & 0xd800) === 0xd800);
+        }
+    }
+
+    return ret + str.substr(lastIdx);
+}
+
+export interface TrieNode {
+    value?: string;
+    next?: Map<number, TrieNode>;
+}
+
+export function getTrie(map: Record<string, string>): Map<number, TrieNode> {
+    const trie = new Map<number, TrieNode>();
+
+    for (const value of Object.keys(map)) {
+        const key = map[value];
+        // Resolve the key
+        let lastMap = trie;
+        for (let i = 0; i < key.length - 1; i++) {
+            const char = key.charCodeAt(i);
+            const next = lastMap.get(char) ?? {};
+            lastMap.set(char, next);
+            lastMap = next.next ??= new Map();
+        }
+        const val = lastMap.get(key.charCodeAt(key.length - 1)) ?? {};
+        val.value ??= `&${value};`;
+        lastMap.set(key.charCodeAt(key.length - 1), val);
+    }
+
+    return trie;
+}

--- a/src/encode.spec.ts
+++ b/src/encode.spec.ts
@@ -4,7 +4,7 @@ describe("Encode->decode test", () => {
     const testcases = [
         {
             input: "asdf & ÿ ü '",
-            xml: "asdf &amp; &#xFF; &#xFC; &apos;",
+            xml: "asdf &amp; &#xff; &#xfc; &apos;",
             html: "asdf &amp; &yuml; &uuml; &apos;",
         },
         {
@@ -33,7 +33,7 @@ describe("Encode->decode test", () => {
             expect(entities.decodeHTML(encodedHTML5)).toBe(input));
         it("should encode emojis", () =>
             expect(entities.encodeHTML5("😄🍾🥳💥😇")).toBe(
-                "&#x1F604;&#x1F37E;&#x1F973;&#x1F4A5;&#x1F607;"
+                "&#x1f604;&#x1f37e;&#x1f973;&#x1f4a5;&#x1f607;"
             ));
     }
 
@@ -52,6 +52,6 @@ describe("encodeNonAsciiHTML", () => {
 
     it("should encode emojis", () =>
         expect(entities.encodeNonAsciiHTML("😄🍾🥳💥😇")).toBe(
-            "&#x1F604;&#x1F37E;&#x1F973;&#x1F4A5;&#x1F607;"
+            "&#x1f604;&#x1f37e;&#x1f973;&#x1f4a5;&#x1f607;"
         ));
 });

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -125,7 +125,7 @@ export const escape = encodeXML;
  *
  * @param data String to escape.
  */
-export function encodeXML_UTF8(data: string): string {
+export function escapeUTF8(data: string): string {
     let match;
     let lastIdx = 0;
     let result = "";

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -57,7 +57,7 @@ describe("Documents", () => {
                         level: i,
                         mode: entities.EncodingMode.ASCII,
                     })
-                ).toBe("Great #&apos;s of &#x1F381;"));
+                ).toBe("Great #&apos;s of &#x1f381;"));
         });
     }
 
@@ -78,8 +78,8 @@ describe("Documents", () => {
 });
 
 const astral = [
-    ["1D306", "\uD834\uDF06"],
-    ["1D11E", "\uD834\uDD1E"],
+    ["1d306", "\uD834\uDF06"],
+    ["1d11e", "\uD834\uDD1E"],
 ];
 
 const astralSpecial = [
@@ -114,5 +114,5 @@ describe("Escape", () => {
     });
 
     it("should keep UTF8 characters", () =>
-        expect(entities.escapeUTF8('ß < "ü"')).toBe(`ß &#x3C; &#x22;ü&#x22;`));
+        expect(entities.escapeUTF8('ß < "ü"')).toBe(`ß &lt; &quot;ü&quot;`));
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { decodeXML, decodeHTML, decodeHTMLStrict } from "./decode";
 import {
     encodeXML,
-    encodeXML_UTF8,
+    escapeUTF8,
     encodeHTML,
     encodeNonAsciiHTML,
 } from "./encode";
@@ -135,7 +135,7 @@ export function encode(
     const opts = typeof options === "number" ? { level: options } : options;
 
     // Mode `UTF8` just escapes XML entities
-    if (opts.mode === EncodingMode.UTF8) return encodeXML_UTF8(data);
+    if (opts.mode === EncodingMode.UTF8) return escapeUTF8(data);
 
     if (opts.level === EntityLevel.HTML) {
         if (opts.mode === EncodingMode.ASCII) {
@@ -154,8 +154,7 @@ export {
     encodeHTML,
     encodeNonAsciiHTML,
     escape,
-    encodeXML_UTF8,
-    encodeXML_UTF8 as escapeUTF8,
+    escapeUTF8,
     // Legacy aliases (deprecated)
     encodeHTML as encodeHTML4,
     encodeHTML as encodeHTML5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { decodeXML, decodeHTML, decodeHTMLStrict } from "./decode";
-import { encodeXML, encodeHTML, encodeNonAsciiHTML } from "./encode";
+import {
+    encodeXML,
+    encodeXML_UTF8,
+    encodeHTML,
+    encodeNonAsciiHTML,
+} from "./encode";
 
 /** The level of entities to support. */
 export enum EntityLevel {
@@ -129,17 +134,16 @@ export function encode(
 ): string {
     const opts = typeof options === "number" ? { level: options } : options;
 
+    // Mode `UTF8` just escapes XML entities
+    if (opts.mode === EncodingMode.UTF8) return encodeXML_UTF8(data);
+
     if (opts.level === EntityLevel.HTML) {
         if (opts.mode === EncodingMode.ASCII) {
             return encodeNonAsciiHTML(data);
         }
 
-        // TODO Support opts.mode === 'UTF8'
-
         return encodeHTML(data);
     }
-
-    // TODO Support opts.mode === 'UTF8'
 
     // ASCII and Extensive are equivalent
     return encodeXML(data);
@@ -150,7 +154,8 @@ export {
     encodeHTML,
     encodeNonAsciiHTML,
     escape,
-    escapeUTF8,
+    encodeXML_UTF8,
+    encodeXML_UTF8 as escapeUTF8,
     // Legacy aliases (deprecated)
     encodeHTML as encodeHTML4,
     encodeHTML as encodeHTML5,


### PR DESCRIPTION
BREAKING: The `escape` methods will now produce XML entities by default, for increased speed.

BREAKING: Numeric entities are now using lowercase characters. They are equivalent, but we skip one unnecessary operation.

This is building on work done for the `decode*` methods. While the `decode` methods are now using a binary decode map, this approach wouldn't work for encoding as the input characters have a much wider range. Instead, one UTF16 character at a time is now considered, also greatly improving performance.

This builds on an insight from @mdevils' `html-entities` library: Turns out that hand-rolling  `String.prototype.replace` actually leads to considerable speed improvements. This PR expands on that by using hand-rolled regexp iteration to speed up finding characters to look up in our trie.