### PR TITLE
feat: Add `escapeAttribute` and `escapeText`

### DIFF
--- a/src/encode.spec.ts
+++ b/src/encode.spec.ts
@@ -71,3 +71,15 @@ describe("encodeNonAsciiHTML", () => {
             "&#x2652;&#xfe0f;&#x2653;&#xfe0f;&#x2648;&#xfe0f;&#x2649;&#xfe0f;&#x264a;&#xfe0f;&#x264b;&#xfe0f;&#x264c;&#xfe0f;&#x264d;&#xfe0f;&#x264e;&#xfe0f;&#x264f;&#xfe0f;&#x2650;&#xfe0f;&#x2651;&#xfe0f;"
         ));
 });
+
+describe("escape HTML", () => {
+    it("should escape HTML attribute values", () =>
+        expect(entities.escapeAttribute('<a " attr > & value \u00a0!')).toBe(
+            "<a &quot; attr > &amp; value &nbsp;!"
+        ));
+
+    it("should escape HTML text", () =>
+        expect(entities.escapeText('<a " text > & value \u00a0!')).toBe(
+            '&lt;a " text &gt; &amp; value &nbsp;!'
+        ));
+});

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -4,12 +4,23 @@ const htmlReplacer = /[\t\n!-,./:-@[-`\f{-}$\x80-\uFFFF]/g;
 const xmlReplacer = /["&'<>$\x80-\uFFFF]/g;
 const xmlInvalidChars = /[&<>'"]/g;
 
+const textReplacer = /[&<>\u00A0]/g;
+const attrReplacer = /["&\u00A0]/g;
+
 const xmlCodeMap = new Map([
     [34, "&quot;"],
     [38, "&amp;"],
     [39, "&apos;"],
     [60, "&lt;"],
     [62, "&gt;"],
+]);
+
+const htmlEscapeCodeMap = new Map([
+    [34, "&quot;"],
+    [38, "&amp;"],
+    [60, "&lt;"],
+    [62, "&gt;"],
+    [160, "&nbsp;"],
 ]);
 
 /**
@@ -107,4 +118,30 @@ export function escapeUTF8(data: string): string {
     }
 
     return result + data.substring(lastIdx);
+}
+
+/**
+ * Encodes all characters that have to be escaped in HTML attributes,
+ * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+ *
+ * @param data String to escape.
+ */
+export function escapeAttribute(data: string): string {
+    return data.replace(
+        attrReplacer,
+        (match) => htmlEscapeCodeMap.get(match.charCodeAt(0))!
+    );
+}
+
+/**
+ * Encodes all characters that have to be escaped in HTML text,
+ * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+ *
+ * @param data String to escape.
+ */
+export function escapeText(data: string): string {
+    return data.replace(
+        textReplacer,
+        (match) => htmlEscapeCodeMap.get(match.charCodeAt(0))!
+    );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import {
     escapeUTF8,
     encodeHTML,
     encodeNonAsciiHTML,
+    escapeAttribute,
+    escapeText,
 } from "./encode";
 
 /** The level of entities to support. */
@@ -39,6 +41,16 @@ export enum EncodingMode {
      * characters that are not ASCII characters.
      */
     Extensive,
+    /**
+     * Encode all characters that have to be escaped in HTML attributes,
+     * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+     */
+    Attribute,
+    /**
+     * Encode all characters that have to be escaped in HTML text,
+     * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
+     */
+    Text,
 }
 
 export interface DecodingOptions {
@@ -136,6 +148,8 @@ export function encode(
 
     // Mode `UTF8` just escapes XML entities
     if (opts.mode === EncodingMode.UTF8) return escapeUTF8(data);
+    if (opts.mode === EncodingMode.Attribute) return escapeAttribute(data);
+    if (opts.mode === EncodingMode.Text) return escapeText(data);
 
     if (opts.level === EntityLevel.HTML) {
         if (opts.mode === EncodingMode.ASCII) {
@@ -155,6 +169,8 @@ export {
     encodeNonAsciiHTML,
     escape,
     escapeUTF8,
+    escapeAttribute,
+    escapeText,
     // Legacy aliases (deprecated)
     encodeHTML as encodeHTML4,
     encodeHTML as encodeHTML5,


### PR DESCRIPTION
They implement the escaping behavior from the html spec: https://html.spec.whatwg.org/multipage/parsing.html#escapingString