### PR TITLE
refactor: Enable `strict-boolean-expressions`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,11 +44,12 @@
                 }
             },
             "rules": {
-                "@typescript-eslint/prefer-for-of": 0,
-                "@typescript-eslint/member-ordering": 0,
-                "@typescript-eslint/explicit-function-return-type": 0,
-                "@typescript-eslint/no-unused-vars": 0,
                 "@typescript-eslint/no-non-null-assertion": 0,
+                "@typescript-eslint/no-unused-vars": [
+                    2,
+                    { "argsIgnorePattern": "^_" }
+                ],
+                "@typescript-eslint/strict-boolean-expressions": 2,
                 "@typescript-eslint/no-use-before-define": [
                     2,
                     { "functions": false }

--- a/src/decode_codepoint.ts
+++ b/src/decode_codepoint.ts
@@ -33,7 +33,7 @@ const decodeMap = new Map([
 
 const fromCodePoint =
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, node/no-unsupported-features/es-builtins
-    String.fromCodePoint ||
+    String.fromCodePoint ??
     function (codePoint: number): string {
         let output = "";
 

--- a/src/encode-trie.ts
+++ b/src/encode-trie.ts
@@ -41,10 +41,10 @@ export function encodeHTMLTrieRe(regExp: RegExp, str: string): string {
                         typeof next.n === "number"
                             ? next.n === str.charCodeAt(i + 1)
                                 ? next.o
-                                : null
+                                : undefined
                             : next.n.get(str.charCodeAt(i + 1));
 
-                    if (value) {
+                    if (value !== undefined) {
                         ret += str.substring(lastIdx, i) + value;
                         lastIdx = regExp.lastIndex += 1;
                         continue;

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -28,7 +28,7 @@ export function encodeXML(str: string): string {
         const char = str.charCodeAt(i);
         const next = xmlCodeMap.get(char);
 
-        if (next) {
+        if (next !== undefined) {
             ret += str.substring(lastIdx, i) + next;
             lastIdx = i + 1;
         } else {


### PR DESCRIPTION
Fixes an inefficiency in `encodeHTMLTrieRe`, and prevents similar issues from happening again.

Also re-enables several previously disabled rules.