### PR TITLE
fix(decode): Fix off-by-one error

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -39,4 +39,7 @@ describe("Decode test", () => {
 
     it("should not parse numeric entities in strict mode", () =>
         expect(entities.decodeHTMLStrict("&#55")).toBe("&#55"));
+
+    it("should parse &nbsp followed by < (#852)", () =>
+        expect(entities.decodeHTML("&nbsp<")).toBe("\u00a0<"));
 });

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -150,7 +150,7 @@ export function determineBranch(
     if (jumpOffset) {
         const value = char - jumpOffset;
 
-        return value < 0 || value > branchCount
+        return value < 0 || value >= branchCount
             ? -1
             : decodeTree[nodeIdx + value] - 1;
     }


### PR DESCRIPTION
Fixes #852

The bug was caused by `<` having the char code of `;` + 1. Replacing `<` with `<=` fixes the issue.

The `determineBranch` function is used by `parse5` and `htmlparser2` as well. The fix will propagate with this patch.