### PR TITLE
chore(package): remove sourcemaps from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
         }
     },
     "files": [
-        "lib/**/*"
+        "lib/**/*.js",
+        "lib/**/*.d.ts"
     ],
     "engines": {
         "node": ">=0.12"


### PR DESCRIPTION
v4 has 4 times larger file size than v3 (v4: 716kB, v3: 168kB, [packagephobia](https://packagephobia.com/result?p=entities)). Although it does not affect the final bundle size of app's using this package, I think smaller is better for file disk usage and install times.

This is because of a) sourcemap is now published and b) ESM support which doubles the files.

This PR removes sourcemaps from npm by the same approach with https://github.com/inikulin/parse5/pull/516.
**This reduces the package size to 295 kB. (-58.8%)**

Since this package uses typescript (that doesn't have ugly outputs) and doesn't run minify, I think the output is readable without sourcemaps and can be removed. Also it seems there are some problems with Webpack (https://github.com/fb55/entities/issues/785).

This PR completely removes sourcemaps. But because most of the size is coming from `lib/generated/*.map`, an alternative approach is to remove only them. (I think these sourcemaps are not much important because it's a generated code.)
This way the package size will be 328 kB.

<details>
<summary>diff for the alternative approach</summary>

- remove `files` field from `package.json`
- add the following `.npmignore`
  ```
  **/*
  !lib/**/*
  lib/generated/*.map
  lib/esm/generated/*.map
  ```

</details>
