### PR TITLE
feat(decode): Add `EntityDecoder` class

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -43,3 +43,48 @@ describe("Decode test", () => {
     it("should parse &nbsp followed by < (#852)", () =>
         expect(entities.decodeHTML("&nbsp<")).toBe("\u00a0<"));
 });
+
+describe("EntityDecoder", () => {
+    it("should decode numeric entities", () => {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+
+        decoder.write("&#x3a;", 1, false);
+
+        expect(cb).toHaveBeenCalledWith(":");
+
+        decoder.end(false);
+
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it("should decode named entities", () => {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+
+        decoder.write("&amp;", 1, false);
+
+        expect(cb).toHaveBeenNthCalledWith(1, "&");
+
+        decoder.end(false);
+
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it("should decode legacy entities", () => {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+
+        decoder.write("&amp", 1, false);
+
+        expect(cb).not.toHaveBeenCalled();
+
+        decoder.end(false);
+
+        expect(cb).toHaveBeenNthCalledWith(1, "&");
+        expect(cb).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -80,7 +80,7 @@ describe("EntityDecoder", () => {
 
         expect(decoder.write("&amp", 1)).toBe(-1);
 
-        expect(cb).not.toHaveBeenCalled();
+        expect(cb).toHaveBeenCalledTimes(0);
 
         expect(decoder.end()).toBe(4);
 
@@ -112,5 +112,130 @@ describe("EntityDecoder", () => {
 
         expect(cb).toHaveBeenCalledTimes(1);
         expect(cb).toHaveBeenCalledWith(":".charCodeAt(0), 6);
+    });
+
+    describe("errors", () => {
+        it("should produce an error for a named entity without a semicolon", () => {
+            const errorHandlers = {
+                missingSemicolonAfterCharacterReference: jest.fn(),
+                absenceOfDigitsInNumericCharacterReference: jest.fn(),
+                validateNumericCharacterReference: jest.fn(),
+            };
+            const cb = jest.fn();
+            const decoder = new entities.EntityDecoder(
+                entities.htmlDecodeTree,
+                cb,
+                errorHandlers
+            );
+
+            decoder.startEntity(entities.EntityDecoderMode.Text);
+            expect(decoder.write("&amp;", 1)).toBe(5);
+            expect(cb).toHaveBeenCalledTimes(1);
+            expect(cb).toHaveBeenCalledWith("&".charCodeAt(0), 5);
+            expect(
+                errorHandlers.missingSemicolonAfterCharacterReference
+            ).toHaveBeenCalledTimes(0);
+
+            decoder.startEntity(entities.EntityDecoderMode.Text);
+            expect(decoder.write("&amp", 1)).toBe(-1);
+            expect(decoder.end()).toBe(4);
+
+            expect(cb).toHaveBeenCalledTimes(2);
+            expect(cb).toHaveBeenLastCalledWith("&".charCodeAt(0), 4);
+            expect(
+                errorHandlers.missingSemicolonAfterCharacterReference
+            ).toHaveBeenCalledTimes(1);
+        });
+
+        it("should produce an error for a numeric entity without a semicolon", () => {
+            const errorHandlers = {
+                missingSemicolonAfterCharacterReference: jest.fn(),
+                absenceOfDigitsInNumericCharacterReference: jest.fn(),
+                validateNumericCharacterReference: jest.fn(),
+            };
+            const cb = jest.fn();
+            const decoder = new entities.EntityDecoder(
+                entities.htmlDecodeTree,
+                cb,
+                errorHandlers
+            );
+
+            decoder.startEntity(entities.EntityDecoderMode.Text);
+            expect(decoder.write("&#x3a", 1)).toBe(-1);
+            expect(decoder.end()).toBe(5);
+
+            expect(cb).toHaveBeenCalledTimes(1);
+            expect(cb).toHaveBeenCalledWith(0x3a, 5);
+            expect(
+                errorHandlers.missingSemicolonAfterCharacterReference
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                errorHandlers.absenceOfDigitsInNumericCharacterReference
+            ).toHaveBeenCalledTimes(0);
+            expect(
+                errorHandlers.validateNumericCharacterReference
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                errorHandlers.validateNumericCharacterReference
+            ).toHaveBeenCalledWith(0x3a);
+        });
+
+        it("should produce an error for numeric entities without digits", () => {
+            const errorHandlers = {
+                missingSemicolonAfterCharacterReference: jest.fn(),
+                absenceOfDigitsInNumericCharacterReference: jest.fn(),
+                validateNumericCharacterReference: jest.fn(),
+            };
+            const cb = jest.fn();
+            const decoder = new entities.EntityDecoder(
+                entities.htmlDecodeTree,
+                cb,
+                errorHandlers
+            );
+
+            decoder.startEntity(entities.EntityDecoderMode.Text);
+            expect(decoder.write("&#", 1)).toBe(-1);
+            expect(decoder.end()).toBe(0);
+
+            expect(cb).toHaveBeenCalledTimes(0);
+            expect(
+                errorHandlers.missingSemicolonAfterCharacterReference
+            ).toHaveBeenCalledTimes(0);
+            expect(
+                errorHandlers.absenceOfDigitsInNumericCharacterReference
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                errorHandlers.validateNumericCharacterReference
+            ).toHaveBeenCalledTimes(0);
+        });
+
+        it("should produce an error for hex entities without digits", () => {
+            const errorHandlers = {
+                missingSemicolonAfterCharacterReference: jest.fn(),
+                absenceOfDigitsInNumericCharacterReference: jest.fn(),
+                validateNumericCharacterReference: jest.fn(),
+            };
+            const cb = jest.fn();
+            const decoder = new entities.EntityDecoder(
+                entities.htmlDecodeTree,
+                cb,
+                errorHandlers
+            );
+
+            decoder.startEntity(entities.EntityDecoderMode.Text);
+            expect(decoder.write("&#x", 1)).toBe(-1);
+            expect(decoder.end()).toBe(0);
+
+            expect(cb).toHaveBeenCalledTimes(0);
+            expect(
+                errorHandlers.missingSemicolonAfterCharacterReference
+            ).toHaveBeenCalledTimes(0);
+            expect(
+                errorHandlers.absenceOfDigitsInNumericCharacterReference
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                errorHandlers.validateNumericCharacterReference
+            ).toHaveBeenCalledTimes(0);
+        });
     });
 });

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -42,6 +42,14 @@ describe("Decode test", () => {
 
     it("should parse &nbsp followed by < (#852)", () =>
         expect(entities.decodeHTML("&nbsp<")).toBe("\u00a0<"));
+
+    it("should decode trailing legacy entities", () => {
+        expect(entities.decodeHTML("&timesbar;&timesbar")).toBe("⨱×bar");
+    });
+
+    it("should decode multi-byte entities", () => {
+        expect(entities.decodeHTML("&NotGreaterFullEqual;")).toBe("≧̸");
+    });
 });
 
 describe("EntityDecoder", () => {

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -52,7 +52,7 @@ describe("EntityDecoder", () => {
         expect(decoder.write("&#x3a;", 1)).toBe(6);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith(":");
+        expect(cb).toHaveBeenCalledWith(":".charCodeAt(0));
     });
 
     it("should decode named entities", () => {
@@ -62,7 +62,7 @@ describe("EntityDecoder", () => {
         expect(decoder.write("&amp;", 1)).toBe(5);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith("&");
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
     });
 
     it("should decode legacy entities", () => {
@@ -77,6 +77,6 @@ describe("EntityDecoder", () => {
         expect(decoder.end()).toBe(4);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith("&");
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
     });
 });

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -79,4 +79,17 @@ describe("EntityDecoder", () => {
         expect(cb).toHaveBeenCalledTimes(1);
         expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
     });
+
+    it("should decode named entity written character by character", () => {
+        const cb = jest.fn();
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
+
+        for (const c of "amp") {
+            expect(decoder.write(c, 0)).toBe(-1);
+        }
+        expect(decoder.write(";", 0)).toBe(5);
+
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
+    });
 });

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -50,6 +50,20 @@ describe("Decode test", () => {
     it("should decode multi-byte entities", () => {
         expect(entities.decodeHTML("&NotGreaterFullEqual;")).toBe("≧̸");
     });
+
+    it("should not decode legacy entities followed by text in attribute mode", () => {
+        expect(
+            entities.decodeHTML("&not", entities.DecodingMode.Attribute)
+        ).toBe("¬");
+
+        expect(
+            entities.decodeHTML("&noti", entities.DecodingMode.Attribute)
+        ).toBe("&noti");
+
+        expect(
+            entities.decodeHTML("&noti=", entities.DecodingMode.Attribute)
+        ).toBe("&noti=");
+    });
 });
 
 describe("EntityDecoder", () => {

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -46,43 +46,40 @@ describe("Decode test", () => {
 
 describe("EntityDecoder", () => {
     it("should decode numeric entities", () => {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
 
-        decoder.write("&#x3a;", 1, false);
+        decoder.write("&#x3a;", 1);
 
         expect(cb).toHaveBeenCalledWith(":");
 
-        decoder.end(false);
+        decoder.end();
 
         expect(cb).toHaveBeenCalledTimes(1);
     });
 
     it("should decode named entities", () => {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
 
-        decoder.write("&amp;", 1, false);
+        decoder.write("&amp;", 1);
 
         expect(cb).toHaveBeenNthCalledWith(1, "&");
 
-        decoder.end(false);
+        decoder.end();
 
         expect(cb).toHaveBeenCalledTimes(1);
     });
 
     it("should decode legacy entities", () => {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const cb: (str: string) => void = jest.fn(() => decoder.reset());
+        const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
 
-        decoder.write("&amp", 1, false);
+        decoder.write("&amp", 1);
 
         expect(cb).not.toHaveBeenCalled();
 
-        decoder.end(false);
+        decoder.end();
 
         expect(cb).toHaveBeenNthCalledWith(1, "&");
         expect(cb).toHaveBeenCalledTimes(1);

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -76,7 +76,7 @@ describe("EntityDecoder", () => {
     it("should decode legacy entities", () => {
         const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
-        decoder.startEntity(entities.EntityDecoderMode.Text);
+        decoder.startEntity(entities.DecodingMode.Legacy);
 
         expect(decoder.write("&amp", 1)).toBe(-1);
 
@@ -128,7 +128,7 @@ describe("EntityDecoder", () => {
                 errorHandlers
             );
 
-            decoder.startEntity(entities.EntityDecoderMode.Text);
+            decoder.startEntity(entities.DecodingMode.Legacy);
             expect(decoder.write("&amp;", 1)).toBe(5);
             expect(cb).toHaveBeenCalledTimes(1);
             expect(cb).toHaveBeenCalledWith("&".charCodeAt(0), 5);
@@ -136,7 +136,7 @@ describe("EntityDecoder", () => {
                 errorHandlers.missingSemicolonAfterCharacterReference
             ).toHaveBeenCalledTimes(0);
 
-            decoder.startEntity(entities.EntityDecoderMode.Text);
+            decoder.startEntity(entities.DecodingMode.Legacy);
             expect(decoder.write("&amp", 1)).toBe(-1);
             expect(decoder.end()).toBe(4);
 
@@ -160,7 +160,7 @@ describe("EntityDecoder", () => {
                 errorHandlers
             );
 
-            decoder.startEntity(entities.EntityDecoderMode.Text);
+            decoder.startEntity(entities.DecodingMode.Legacy);
             expect(decoder.write("&#x3a", 1)).toBe(-1);
             expect(decoder.end()).toBe(5);
 
@@ -193,7 +193,7 @@ describe("EntityDecoder", () => {
                 errorHandlers
             );
 
-            decoder.startEntity(entities.EntityDecoderMode.Text);
+            decoder.startEntity(entities.DecodingMode.Legacy);
             expect(decoder.write("&#", 1)).toBe(-1);
             expect(decoder.end()).toBe(0);
 
@@ -222,7 +222,7 @@ describe("EntityDecoder", () => {
                 errorHandlers
             );
 
-            decoder.startEntity(entities.EntityDecoderMode.Text);
+            decoder.startEntity(entities.DecodingMode.Legacy);
             expect(decoder.write("&#x", 1)).toBe(-1);
             expect(decoder.end()).toBe(0);
 

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -68,6 +68,7 @@ describe("EntityDecoder", () => {
     it("should decode legacy entities", () => {
         const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
+        decoder.startEntity(entities.EntityDecoderMode.Text);
 
         expect(decoder.write("&amp", 1)).toBe(-1);
 

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -47,41 +47,35 @@ describe("Decode test", () => {
 describe("EntityDecoder", () => {
     it("should decode numeric entities", () => {
         const cb = jest.fn();
-        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
 
-        decoder.write("&#x3a;", 1);
-
-        expect(cb).toHaveBeenCalledWith(":");
-
-        decoder.end();
+        expect(decoder.write("&#x3a;", 1)).toBe(6);
 
         expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith(":");
     });
 
     it("should decode named entities", () => {
         const cb = jest.fn();
-        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
 
-        decoder.write("&amp;", 1);
-
-        expect(cb).toHaveBeenNthCalledWith(1, "&");
-
-        decoder.end();
+        expect(decoder.write("&amp;", 1)).toBe(5);
 
         expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith("&");
     });
 
     it("should decode legacy entities", () => {
         const cb = jest.fn();
-        const decoder = new entities.EntityDecoder(entities.xmlDecodeTree, cb);
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
 
-        decoder.write("&amp", 1);
+        expect(decoder.write("&amp", 1)).toBe(-1);
 
         expect(cb).not.toHaveBeenCalled();
 
-        decoder.end();
+        expect(decoder.end()).toBe(4);
 
-        expect(cb).toHaveBeenNthCalledWith(1, "&");
         expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith("&");
     });
 });

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -52,7 +52,7 @@ describe("EntityDecoder", () => {
         expect(decoder.write("&#x3a;", 1)).toBe(6);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith(":".charCodeAt(0));
+        expect(cb).toHaveBeenCalledWith(":".charCodeAt(0), 6);
     });
 
     it("should decode named entities", () => {
@@ -62,7 +62,7 @@ describe("EntityDecoder", () => {
         expect(decoder.write("&amp;", 1)).toBe(5);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0), 5);
     });
 
     it("should decode legacy entities", () => {
@@ -77,7 +77,7 @@ describe("EntityDecoder", () => {
         expect(decoder.end()).toBe(4);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0), 4);
     });
 
     it("should decode named entity written character by character", () => {
@@ -90,6 +90,19 @@ describe("EntityDecoder", () => {
         expect(decoder.write(";", 0)).toBe(5);
 
         expect(cb).toHaveBeenCalledTimes(1);
-        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0));
+        expect(cb).toHaveBeenCalledWith("&".charCodeAt(0), 5);
+    });
+
+    it("should decode numeric entity written character by character", () => {
+        const cb = jest.fn();
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
+
+        for (const c of "#x3a") {
+            expect(decoder.write(c, 0)).toBe(-1);
+        }
+        expect(decoder.write(";", 0)).toBe(6);
+
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith(":".charCodeAt(0), 6);
     });
 });

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -301,11 +301,11 @@ export class EntityDecoder {
         this.emitCodePoint(replaceCodePoint(this.result), this.consumed);
 
         if (this.errors) {
-            this.errors.validateNumericCharacterReference(this.result);
-
             if (lastCp !== CharCodes.SEMI) {
                 this.errors.missingSemicolonAfterCharacterReference();
             }
+
+            this.errors.validateNumericCharacterReference(this.result);
         }
 
         return this.consumed;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -84,7 +84,9 @@ export enum DecodingMode {
  */
 export interface EntityErrorProducer {
     missingSemicolonAfterCharacterReference(): void;
-    absenceOfDigitsInNumericCharacterReference(): void;
+    absenceOfDigitsInNumericCharacterReference(
+        consumedCharacters: number
+    ): void;
     validateNumericCharacterReference(code: number): void;
 }
 
@@ -193,8 +195,7 @@ export class EntityDecoder {
             return -1;
         }
 
-        const char = str.charCodeAt(offset);
-        if ((char | TO_LOWER_BIT) === CharCodes.LOWER_X) {
+        if ((str.charCodeAt(offset) | TO_LOWER_BIT) === CharCodes.LOWER_X) {
             this.state = EntityDecoderState.NumericHex;
             this.consumed += 1;
             return this.stateNumericHex(str, offset + 1);
@@ -287,7 +288,9 @@ export class EntityDecoder {
     private emitNumericEntity(lastCp: number, expectedLength: number): number {
         // Ensure we consumed at least one digit.
         if (this.consumed <= expectedLength) {
-            this.errors?.absenceOfDigitsInNumericCharacterReference();
+            this.errors?.absenceOfDigitsInNumericCharacterReference(
+                this.consumed
+            );
             return 0;
         }
 
@@ -446,7 +449,9 @@ export class EntityDecoder {
                 return this.emitNumericEntity(0, 3);
             }
             case EntityDecoderState.NumericStart: {
-                this.errors?.absenceOfDigitsInNumericCharacterReference();
+                this.errors?.absenceOfDigitsInNumericCharacterReference(
+                    this.consumed
+                );
                 return 0;
             }
             case EntityDecoderState.EntityStart: {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -223,7 +223,7 @@ export class EntityDecoder {
     }
 
     private emitNumericEntity(lastCp: number): number {
-        // TODO Figure out if this is a legit end of the entity
+        // Figure out if this is a legit end of the entity
         if (lastCp === CharCodes.SEMI) {
             this.consumed += 1;
         } else if (this.decodeMode === EntityDecoderMode.Strict) {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -355,11 +355,11 @@ function getDecoder(decodeTree: Uint16Array) {
             ? EntityDecoderMode.Strict
             : EntityDecoderMode.Text;
 
-        let lastIdx = 0;
+        let lastIndex = 0;
         let offset = 0;
 
         while ((offset = str.indexOf("&", offset)) >= 0) {
-            ret += str.slice(lastIdx, offset);
+            ret += str.slice(lastIndex, offset);
 
             decoder.startEntity(decodeMode);
 
@@ -370,16 +370,16 @@ function getDecoder(decodeTree: Uint16Array) {
             );
 
             if (len < 0) {
-                lastIdx = offset + decoder.end();
+                lastIndex = offset + decoder.end();
                 break;
             }
 
-            lastIdx = offset + len;
+            lastIndex = offset + len;
             // If `len` is 0, skip the current `&` and continue.
-            offset = len === 0 ? lastIdx + 1 : lastIdx;
+            offset = len === 0 ? lastIndex + 1 : lastIndex;
         }
 
-        const result = ret + str.slice(lastIdx);
+        const result = ret + str.slice(lastIndex);
 
         // Make sure we don't keep a reference to the final string.
         ret = "";

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -98,8 +98,8 @@ export class EntityDecoder {
         /**
          * The function that is called when a codepoint is decoded.
          *
-         * For multi-byte named entities, this will be called multiple times,
-         * with the second codepoint, and the same `consumed` value.
+         * For multi-byte named entities, this will be called a second time.
+         * For the second call, `consumed` will be 0.
          *
          * @param codepoint The decoded codepoint.
          * @param consumed The number of bytes consumed by the decoder.
@@ -415,7 +415,7 @@ export class EntityDecoder {
         );
         if (valueLength === 3) {
             // For multi-byte values, we need to emit the second byte.
-            this.emitCodePoint(decodeTree[result + 2], consumed);
+            this.emitCodePoint(decodeTree[result + 2], 0);
         }
 
         return consumed;

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -153,10 +153,10 @@ export class EntityDecoder {
             this.codepoint =
                 this.codepoint * 16 + parseInt(str.slice(startIdx, strIdx), 16);
             this.consumed += strIdx - startIdx;
-        }
 
-        if (strIdx < str.length) {
-            return this.emitNumericEntity(str.charCodeAt(strIdx));
+            if (strIdx < str.length) {
+                return this.emitNumericEntity(str.charCodeAt(strIdx));
+            }
         }
 
         return -1;
@@ -173,10 +173,10 @@ export class EntityDecoder {
             this.codepoint =
                 this.codepoint * 10 + parseInt(str.slice(startIdx, strIdx), 10);
             this.consumed += strIdx - startIdx;
-        }
 
-        if (strIdx < str.length) {
-            return this.emitNumericEntity(str.charCodeAt(strIdx));
+            if (strIdx < str.length) {
+                return this.emitNumericEntity(str.charCodeAt(strIdx));
+            }
         }
 
         return -1;
@@ -263,15 +263,23 @@ export class EntityDecoder {
     }
 
     end(): number {
-        // Emit entity if we have one.
+        // Emit a named entity if we have one.
         if (this.resultIdx !== 0) {
             return this.emitNamedEntity();
         }
-        // TODO Make it possible to emit eg. &#000; here.
-        if (this.codepoint !== 0) {
+
+        // Otherwise, emit a numeric entity if we have one.
+        if (
+            this.codepoint !== 0 ||
+            // Make it possible to emit eg. &#000; here.
+            (this.consumed > 2 &&
+                (this.state === EntityDecoderState.NumericDecimal ||
+                    this.consumed > 3))
+        ) {
             return this.emitNumericEntity(0);
         }
 
+        // Return 0 if we have no entity.
         return 0;
     }
 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -462,6 +462,12 @@ export class EntityDecoder {
     }
 }
 
+/**
+ * Creates a function that decodes entities in a string.
+ *
+ * @param decodeTree The decode tree.
+ * @returns A function that decodes entities in a string.
+ */
 function getDecoder(decodeTree: Uint16Array) {
     let ret = "";
     const decoder = new EntityDecoder(
@@ -506,6 +512,16 @@ function getDecoder(decodeTree: Uint16Array) {
     };
 }
 
+/**
+ * Determines the branch of the current node that is taken given the current
+ * character. This function is used to traverse the trie.
+ *
+ * @param decodeTree The trie.
+ * @param current The current node.
+ * @param nodeIdx The index right after the current node and its value.
+ * @param char The current character.
+ * @returns The index of the next node, or -1 if no branch is taken.
+ */
 export function determineBranch(
     decodeTree: Uint16Array,
     current: number,

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -338,8 +338,12 @@ export class EntityDecoder {
 
             if (this.treeIndex < 0) {
                 return this.result === 0 ||
+                    // If we are parsing an attribute
                     (this.decodeMode === DecodingMode.Attribute &&
-                        isEntityInAttributeInvalidEnd(char))
+                        // We shouldn't have consumed any characters after the entity,
+                        (valueLength === 0 ||
+                            // And there should be no invalid characters.
+                            isEntityInAttributeInvalidEnd(char)))
                     ? 0
                     : this.emitNotTerminatedNamedEntity();
             }
@@ -428,7 +432,9 @@ export class EntityDecoder {
         switch (this.state) {
             case EntityDecoderState.NamedEntity: {
                 // Emit a named entity if we have one.
-                return this.result !== 0
+                return this.result !== 0 &&
+                    (this.decodeMode !== DecodingMode.Attribute ||
+                        this.result === this.treeIndex)
                     ? this.emitNotTerminatedNamedEntity()
                     : 0;
             }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -100,7 +100,7 @@ export class EntityDecoder {
      */
     private result = 0;
 
-    private treeIdx = 0;
+    private treeIndex = 0;
     private excess = 1;
     private decodeMode = EntityDecoderMode.Strict;
 
@@ -109,7 +109,7 @@ export class EntityDecoder {
         this.decodeMode = decodeMode;
         this.state = EntityDecoderState.EntityStart;
         this.result = 0;
-        this.treeIdx = 0;
+        this.treeIndex = 0;
         this.excess = 1;
         this.consumed = 1;
     }
@@ -238,21 +238,21 @@ export class EntityDecoder {
 
     private stateNamedEntity(str: string, strIdx: number): number {
         const { decodeTree } = this;
-        let current = decodeTree[this.treeIdx];
+        let current = decodeTree[this.treeIndex];
         // The mask is the number of bytes of the value, including the current byte.
         let valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14;
 
         for (; strIdx < str.length; strIdx++, this.excess++) {
             const char = str.charCodeAt(strIdx);
 
-            this.treeIdx = determineBranch(
+            this.treeIndex = determineBranch(
                 decodeTree,
                 current,
-                this.treeIdx + Math.max(1, valueLength),
+                this.treeIndex + Math.max(1, valueLength),
                 char
             );
 
-            if (this.treeIdx < 0) {
+            if (this.treeIndex < 0) {
                 return this.result === 0 ||
                     (this.decodeMode === EntityDecoderMode.Attribute &&
                         isEntityInAttributeInvalidEnd(char))
@@ -260,7 +260,7 @@ export class EntityDecoder {
                     : this.emitNamedEntity();
             }
 
-            current = decodeTree[this.treeIdx];
+            current = decodeTree[this.treeIndex];
             valueLength = (current & BinTrieFlags.VALUE_LENGTH) >> 14;
 
             // If the branch is a value, store it and continue
@@ -268,7 +268,7 @@ export class EntityDecoder {
                 // If the entity is terminated by a semicolon, we are done.
                 if (char === CharCodes.SEMI) {
                     return this.emitNamedEntityData(
-                        this.treeIdx,
+                        this.treeIndex,
                         valueLength,
                         this.consumed + this.excess
                     );
@@ -276,7 +276,7 @@ export class EntityDecoder {
 
                 // If we encounter a non-terminated (legacy) entity while parsing strictly, then ignore it.
                 if (this.decodeMode !== EntityDecoderMode.Strict) {
-                    this.result = this.treeIdx;
+                    this.result = this.treeIndex;
                     this.consumed += this.excess;
                     this.excess = 0;
                 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -98,8 +98,8 @@ export class EntityDecoder {
         /**
          * The function that is called when a codepoint is decoded.
          *
-         * For multi-byte named entities, this will be called a second time.
-         * For the second call, `consumed` will be 0.
+         * For multi-byte named entities, this will be called multiple times,
+         * with the second codepoint, and the same `consumed` value.
          *
          * @param codepoint The decoded codepoint.
          * @param consumed The number of bytes consumed by the decoder.
@@ -415,7 +415,7 @@ export class EntityDecoder {
         );
         if (valueLength === 3) {
             // For multi-byte values, we need to emit the second byte.
-            this.emitCodePoint(decodeTree[result + 2], 0);
+            this.emitCodePoint(decodeTree[result + 2], consumed);
         }
 
         return consumed;

--- a/src/decode_codepoint.ts
+++ b/src/decode_codepoint.ts
@@ -31,6 +31,9 @@ const decodeMap = new Map([
     [159, 376],
 ]);
 
+/**
+ * Polyfill for `String.fromCodePoint`. It is used to create a string from a Unicode code point.
+ */
 export const fromCodePoint =
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, node/no-unsupported-features/es-builtins
     String.fromCodePoint ??
@@ -49,6 +52,11 @@ export const fromCodePoint =
         return output;
     };
 
+/**
+ * Replace the given code point with a replacement character if it is a
+ * surrogate or is outside the valid range. Otherwise return the code
+ * point unchanged.
+ */
 export function replaceCodePoint(codePoint: number) {
     if ((codePoint >= 0xd800 && codePoint <= 0xdfff) || codePoint > 0x10ffff) {
         return 0xfffd;

--- a/src/decode_codepoint.ts
+++ b/src/decode_codepoint.ts
@@ -2,6 +2,7 @@
 
 const decodeMap = new Map([
     [0, 65533],
+    // C1 Unicode control character reference replacements
     [128, 8364],
     [130, 8218],
     [131, 402],
@@ -65,6 +66,13 @@ export function replaceCodePoint(codePoint: number) {
     return decodeMap.get(codePoint) ?? codePoint;
 }
 
+/**
+ * Replace the code point if relevant, then convert it to a string.
+ *
+ * @deprecated Use `fromCodePoint(replaceCodePoint(codePoint))` instead.
+ * @param codePoint The code point to decode.
+ * @returns The decoded code point.
+ */
 export default function decodeCodePoint(codePoint: number): string {
     return fromCodePoint(replaceCodePoint(codePoint));
 }

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -68,6 +68,16 @@ export function encodeXML(str: string): string {
  */
 export const escape = encodeXML;
 
+/**
+ * Creates a function that escapes all characters matched by the given regular
+ * expression using the given map of characters to escape to their entities.
+ *
+ * @param regex Regular expression to match characters to escape.
+ * @param map Map of characters to escape to their entities.
+ *
+ * @returns Function that escapes all characters matched by the given regular
+ * expression using the given map of characters to escape to their entities.
+ */
 function getEscaper(
     regex: RegExp,
     map: Map<number, string>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-import { decodeXML, decodeHTML, decodeHTMLStrict } from "./decode.js";
+import {
+    decodeXML,
+    decodeHTML,
+    decodeHTMLStrict,
+    DecodingMode,
+} from "./decode.js";
 import { encodeHTML, encodeNonAsciiHTML } from "./encode.js";
 import {
     encodeXML,
@@ -13,14 +18,6 @@ export enum EntityLevel {
     XML = 0,
     /** Support HTML entities, which are a superset of XML entities. */
     HTML = 1,
-}
-
-/** Determines whether some entities are allowed to be written without a trailing `;`. */
-export enum DecodingMode {
-    /** Support legacy HTML entities. */
-    Legacy = 0,
-    /** Do not support legacy HTML entities. */
-    Strict = 1,
 }
 
 export enum EncodingMode {
@@ -108,10 +105,7 @@ export function decodeStrict(
     const opts = typeof options === "number" ? { level: options } : options;
 
     if (opts.level === EntityLevel.HTML) {
-        if (opts.mode === DecodingMode.Legacy) {
-            return decodeHTML(data);
-        }
-        return decodeHTMLStrict(data);
+        return decodeHTML(data, opts.mode);
     }
 
     return decodeXML(data);
@@ -179,9 +173,12 @@ export {
 } from "./encode.js";
 
 export {
+    EntityDecoder,
+    DecodingMode,
     decodeXML,
     decodeHTML,
     decodeHTMLStrict,
+    decodeHTMLAttribute,
     // Legacy aliases (deprecated)
     decodeHTML as decodeHTML4,
     decodeHTML as decodeHTML5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,4 @@
-import {
-    decodeXML,
-    decodeHTML,
-    decodeHTMLStrict,
-    DecodingMode,
-} from "./decode.js";
+import { decodeXML, decodeHTML, DecodingMode } from "./decode.js";
 import { encodeHTML, encodeNonAsciiHTML } from "./encode.js";
 import {
     encodeXML,
@@ -79,13 +74,11 @@ export function decode(
     data: string,
     options: DecodingOptions | EntityLevel = EntityLevel.XML
 ): string {
-    const opts = typeof options === "number" ? { level: options } : options;
+    const level = typeof options === "number" ? options : options.level;
 
-    if (opts.level === EntityLevel.HTML) {
-        if (opts.mode === DecodingMode.Strict) {
-            return decodeHTMLStrict(data);
-        }
-        return decodeHTML(data);
+    if (level === EntityLevel.HTML) {
+        const mode = typeof options === "object" ? options.mode : undefined;
+        return decodeHTML(data, mode);
     }
 
     return decodeXML(data);
@@ -103,12 +96,9 @@ export function decodeStrict(
     options: DecodingOptions | EntityLevel = EntityLevel.XML
 ): string {
     const opts = typeof options === "number" ? { level: options } : options;
+    opts.mode ??= DecodingMode.Strict;
 
-    if (opts.level === EntityLevel.HTML) {
-        return decodeHTML(data, opts.mode);
-    }
-
-    return decodeXML(data);
+    return decode(data, opts);
 }
 
 /**


### PR DESCRIPTION
This class can be used by parsers that rely on `entities` to elegantly parse chunked entities (eg. from streams). Also adds support for parsing HTML entities in attributes.