### PR TITLE
fix(decode): Handle chunks for numeric entities

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -144,6 +144,19 @@ describe("EntityDecoder", () => {
         expect(cb).toHaveBeenCalledWith(":".charCodeAt(0), 6);
     });
 
+    it("should decode hex entities across several chunks", () => {
+        const cb = jest.fn();
+        const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);
+
+        for (const chunk of ["#x", "cf", "ff", "d"]) {
+            expect(decoder.write(chunk, 0)).toBe(-1);
+        }
+
+        expect(decoder.write(";", 0)).toBe(9);
+        expect(cb).toHaveBeenCalledTimes(1);
+        expect(cb).toHaveBeenCalledWith(0xcfffd, 9);
+    });
+
     it("should not fail if nothing is written", () => {
         const cb = jest.fn();
         const decoder = new entities.EntityDecoder(entities.htmlDecodeTree, cb);

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -212,9 +212,11 @@ export class EntityDecoder {
         base: number
     ): void {
         if (start !== end) {
+            const digitCount = end - start;
             this.result =
-                this.result * base + parseInt(str.slice(start, end), base);
-            this.consumed += end - start;
+                this.result * Math.pow(base, digitCount) +
+                parseInt(str.substr(start, digitCount), base);
+            this.consumed += digitCount;
         }
     }
 


### PR DESCRIPTION
Previously, only chunks of size 1 were supported.