### PR TITLE
`browser` target for esbuild support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
     "module": "lib/esm/index.js",
+    "browser": "lib/esm/index.js",
     "exports": {
         ".": {
             "require": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -22,16 +22,19 @@
     "browser": "lib/esm/index.js",
     "exports": {
         ".": {
-            "require": "./lib/index.js",
-            "import": "./lib/esm/index.js"
+            "browser": "./lib/esm/index.js",
+            "import": "./lib/esm/index.js",
+            "require": "./lib/index.js"
         },
         "./lib/decode.js": {
-            "require": "./lib/decode.js",
-            "import": "./lib/esm/decode.js"
+            "browser": "./lib/esm/decode.js",
+            "import": "./lib/esm/decode.js",
+            "require": "./lib/decode.js"
         },
         "./lib/escape.js": {
-            "require": "./lib/escape.js",
-            "import": "./lib/esm/escape.js"
+            "browser": "./lib/esm/escape.js",
+            "import": "./lib/esm/escape.js",
+            "require": "./lib/escape.js"
         }
     },
     "files": [


### PR DESCRIPTION
In order to be compatibly with `esbuild` using `browser` platform, need to specify `browser` field in `package.json` because `main` field [have high priority](https://esbuild.github.io/api/#platform) over `import` by default 🫠