### PR TITLE
Simplify export paths, make work in old NodeJS

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -1,0 +1,3 @@
+// Make exports work in Node < 12
+// eslint-disable-next-line no-undef, unicorn/prefer-module
+module.exports = require("./dist/commonjs/decode.js");

--- a/escape.js
+++ b/escape.js
@@ -1,0 +1,3 @@
+// Make exports work in Node < 12
+// eslint-disable-next-line no-undef, unicorn/prefer-module
+module.exports = require("./dist/commonjs/escape.js");

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
                 "default": "./dist/commonjs/index.js"
             }
         },
-        "./dist/decode.js": {
+        "./decode": {
             "import": {
                 "types": "./dist/esm/decode.d.ts",
                 "default": "./dist/esm/decode.js"
@@ -41,7 +41,7 @@
                 "default": "./dist/commonjs/decode.js"
             }
         },
-        "./dist/escape.js": {
+        "./escape": {
             "import": {
                 "types": "./dist/esm/escape.d.ts",
                 "default": "./dist/esm/escape.js"
@@ -108,8 +108,8 @@
         ],
         "exports": {
             ".": "./src/index.ts",
-            "./dist/decode.js": "./src/decode.ts",
-            "./dist/escape.js": "./src/escape.ts"
+            "./decode": "./src/decode.ts",
+            "./escape": "./src/escape.ts"
         }
     }
 }


### PR DESCRIPTION
The paths previously didn't work in old NodeJS versions, now they do.

BREAKING change.