### PR TITLE
fix: add types for old node entry points

### DIFF
--- a/decode.d.ts
+++ b/decode.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/commonjs/decode.js";

--- a/escape.d.ts
+++ b/escape.d.ts
@@ -1,0 +1,1 @@
+export * from "./dist/commonjs/escape.js";


### PR DESCRIPTION
In older node, we introduced these top level files because `exports` won't be understood. However, typescript is sad when we use it since there are no types!

this should fix the parse5 entities problem people have been having @fb55 