### PR TITLE
Speed up encodes using bitsets

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,5 +1,5 @@
 import { htmlTrie } from "./generated/encode-html.js";
-import { getCodePoint } from "./escape.js";
+import { getCodePoint, XML_BITSET_VALUE } from "./escape.js";
 
 /**
  * We store the characters to consider as a compact bitset for fast lookups.
@@ -11,13 +11,7 @@ const HTML_BITSET = /* #__PURE__ */ new Uint32Array([
     0x38_00_00_01, // 96..127-> 60, 7B-7D
 ]);
 
-const XML_BITSET = /* #__PURE__ */ new Uint32Array([
-    // Non-ASCII mode
-    0, // 0..31
-    0x50_00_00_d4, // 32..63 -> 34,36,38,39,60,62
-    0, // 64..95
-    0, // 96..127
-]);
+const XML_BITSET = /* #__PURE__ */ new Uint32Array([0, XML_BITSET_VALUE, 0, 0]);
 
 /**
  * Encodes all characters in the input using HTML entities. This includes
@@ -53,7 +47,7 @@ function encodeHTMLTrieRe(bitset: Uint32Array, input: string): string {
     for (let index = 0; index < length; index++) {
         const char = input.charCodeAt(index);
         // Skip ASCII characters that don't need encoding
-        if (char < 0x80 && ((bitset[char >>> 5] >>> (char & 31)) & 1) === 0) {
+        if (char < 0x80 && !((bitset[char >>> 5] >>> char) & 1)) {
             continue;
         }
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -1,7 +1,23 @@
 import { htmlTrie } from "./generated/encode-html.js";
-import { xmlReplacer, getCodePoint } from "./escape.js";
+import { getCodePoint } from "./escape.js";
 
-const htmlReplacer = /[\t\n\f!-,./:-@[-`{-}\u0080-\uFFFF]/g;
+/**
+ * We store the characters to consider as a compact bitset for fast lookups.
+ */
+const HTML_BITSET = /* #__PURE__ */ new Uint32Array([
+    0x16_00, // Bits for 09,0A,0C
+    0xfc_00_ff_fe, // 32..63 -> 21-2D (minus space), 2E,2F,3A-3F
+    0xf8_00_00_01, // 64..95 -> 40, 5B-5F
+    0x38_00_00_01, // 96..127-> 60, 7B-7D
+]);
+
+const XML_BITSET = /* #__PURE__ */ new Uint32Array([
+    // Non-ASCII mode
+    0, // 0..31
+    0x50_00_00_d4, // 32..63 -> 34,36,38,39,60,62
+    0, // 64..95
+    0, // 96..127
+]);
 
 /**
  * Encodes all characters in the input using HTML entities. This includes
@@ -15,7 +31,7 @@ const htmlReplacer = /[\t\n\f!-,./:-@[-`{-}\u0080-\uFFFF]/g;
  * (eg. `&#xfc;`) will be used.
  */
 export function encodeHTML(input: string): string {
-    return encodeHTMLTrieRe(htmlReplacer, input);
+    return encodeHTMLTrieRe(HTML_BITSET, input);
 }
 /**
  * Encodes all non-ASCII characters, as well as characters not valid in HTML
@@ -26,52 +42,58 @@ export function encodeHTML(input: string): string {
  * (eg. `&#xfc;`) will be used.
  */
 export function encodeNonAsciiHTML(input: string): string {
-    return encodeHTMLTrieRe(xmlReplacer, input);
+    return encodeHTMLTrieRe(XML_BITSET, input);
 }
 
-function encodeHTMLTrieRe(regExp: RegExp, input: string): string {
-    let returnValue = "";
-    let lastIndex = 0;
-    let match;
+function encodeHTMLTrieRe(bitset: Uint32Array, input: string): string {
+    let out: string | undefined;
+    let last = 0; // Start of the next untouched slice.
+    const { length } = input;
 
-    while ((match = regExp.exec(input)) !== null) {
-        const { index } = match;
-        returnValue += input.substring(lastIndex, index);
+    for (let index = 0; index < length; index++) {
         const char = input.charCodeAt(index);
-        let next = htmlTrie.get(char);
+        // Skip ASCII characters that don't need encoding
+        if (char < 0x80 && ((bitset[char >>> 5] >>> (char & 31)) & 1) === 0) {
+            continue;
+        }
 
-        if (typeof next === "object") {
-            // We are in a branch. Try to match the next char.
-            if (index + 1 < input.length) {
+        if (out === undefined) out = input.substring(0, index);
+        else if (last !== index) out += input.substring(last, index);
+
+        let node = htmlTrie.get(char);
+
+        if (typeof node === "object") {
+            if (index + 1 < length) {
                 const nextChar = input.charCodeAt(index + 1);
                 const value =
-                    typeof next.next === "number"
-                        ? next.next === nextChar
-                            ? next.nextValue
+                    typeof node.next === "number"
+                        ? node.next === nextChar
+                            ? node.nextValue
                             : undefined
-                        : next.next.get(nextChar);
+                        : node.next.get(nextChar);
 
                 if (value !== undefined) {
-                    returnValue += value;
-                    lastIndex = regExp.lastIndex += 1;
+                    out += value;
+                    index++;
+                    last = index + 1;
                     continue;
                 }
             }
-
-            next = next.value;
+            node = node.value;
         }
 
-        // We might have a tree node without a value; skip and use a numeric entity.
-        if (next === undefined) {
+        if (node === undefined) {
             const cp = getCodePoint(input, index);
-            returnValue += `&#x${cp.toString(16)};`;
-            // Increase by 1 if we have a surrogate pair
-            lastIndex = regExp.lastIndex += Number(cp !== char);
+            out += `&#x${cp.toString(16)};`;
+            if (cp !== char) index++;
+            last = index + 1;
         } else {
-            returnValue += next;
-            lastIndex = index + 1;
+            out += node;
+            last = index + 1;
         }
     }
 
-    return returnValue + input.substr(lastIndex);
+    if (out === undefined) return input;
+    if (last < length) out += input.substr(last);
+    return out;
 }

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -21,12 +21,9 @@ export const getCodePoint: (c: string, index: number) => number =
           (input: string, index: number): number => input.codePointAt(index)!;
 
 /**
- * Bitset for ASCII characters that need to be escaped in XML, limited to the
- * first 64 code points (0..63). We only need to escape: '"' (34), '&' (38),
- * "'" (39), '<' (60), '>' (62) – all within 0..63. Using only two 32-bit
- * entries reduces bounds checks and memory.
+ * Bitset for ASCII characters that need to be escaped in XML.
  */
-const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34,38,39,60,62
+export const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34 ("),38 (&),39 ('),60 (<),62 (>)
 
 /**
  * Encodes all non-ASCII characters, as well as characters not valid in XML
@@ -46,9 +43,7 @@ export function encodeXML(input: string): string {
         // Check for ASCII chars that don't need escaping
         if (
             char < 0x80 &&
-            (char >= 64 ||
-                char < 32 ||
-                ((XML_BITSET_VALUE >>> (char & 31)) & 1) === 0)
+            (((XML_BITSET_VALUE >>> char) & 1) === 0 || char >= 64 || char < 32)
         ) {
             continue;
         }

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -1,5 +1,3 @@
-export const xmlReplacer: RegExp = /["$&'<>\u0080-\uFFFF]/g;
-
 const xmlCodeMap = new Map([
     [34, "&quot;"],
     [38, "&amp;"],
@@ -23,38 +21,58 @@ export const getCodePoint: (c: string, index: number) => number =
           (input: string, index: number): number => input.codePointAt(index)!;
 
 /**
+ * Bitset for ASCII characters that need to be escaped in XML, limited to the
+ * first 64 code points (0..63). We only need to escape: '"' (34), '&' (38),
+ * "'" (39), '<' (60), '>' (62) – all within 0..63. Using only two 32-bit
+ * entries reduces bounds checks and memory.
+ */
+const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34,38,39,60,62
+
+/**
  * Encodes all non-ASCII characters, as well as characters not valid in XML
- * documents using XML entities.
+ * documents using XML entities. Uses a fast bitset scan instead of RegExp.
  *
- * If a character has no equivalent entity, a
- * numeric hexadecimal reference (eg. `&#xfc;`) will be used.
+ * If a character has no equivalent entity, a numeric hexadecimal reference
+ * (eg. `&#xfc;`) will be used.
  */
 export function encodeXML(input: string): string {
-    let returnValue = "";
-    let lastIndex = 0;
-    let match;
+    let out: string | undefined;
+    let last = 0;
+    const { length } = input;
 
-    while ((match = xmlReplacer.exec(input)) !== null) {
-        const { index } = match;
+    for (let index = 0; index < length; index++) {
         const char = input.charCodeAt(index);
-        const next = xmlCodeMap.get(char);
 
-        if (next === undefined) {
-            returnValue += `${input.substring(lastIndex, index)}&#x${getCodePoint(
-                input,
-                index,
-            ).toString(16)};`;
-            // Increase by 1 if we have a surrogate pair
-            lastIndex = xmlReplacer.lastIndex += Number(
-                (char & 0xfc_00) === 0xd8_00,
-            );
-        } else {
-            returnValue += input.substring(lastIndex, index) + next;
-            lastIndex = index + 1;
+        // Check for ASCII chars that don't need escaping
+        if (
+            char < 0x80 &&
+            (char >= 64 ||
+                char < 32 ||
+                ((XML_BITSET_VALUE >>> (char & 31)) & 1) === 0)
+        ) {
+            continue;
         }
+
+        if (out === undefined) out = input.substring(0, index);
+        else if (last !== index) out += input.substring(last, index);
+
+        if (char < 64) {
+            // Known replacement
+            out += xmlCodeMap.get(char)!;
+            last = index + 1;
+            continue;
+        }
+
+        // Non-ASCII: encode as numeric entity (handle surrogate pair)
+        const cp = getCodePoint(input, index);
+        out += `&#x${cp.toString(16)};`;
+        if (cp !== char) index++; // Skip trailing surrogate
+        last = index + 1;
     }
 
-    return returnValue + input.substr(lastIndex);
+    if (out === undefined) return input;
+    if (last < length) out += input.substr(last);
+    return out;
 }
 
 /**


### PR DESCRIPTION
Uses bitmaps to replace regex when looking for ASCII code points that should be replaced with entities. Leads to a ~1.6x speed up.