### PR TITLE
chore: don't bring source files to end-user

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
         "decode.d.ts",
         "escape.js",
         "escape.d.ts",
-        "dist",
-        "src"
+        "dist"
     ],
     "scripts": {
         "build:docs": "typedoc --hideGenerator src/index.ts",


### PR DESCRIPTION
Remove source files to end-user package. I see if this is reducing ±20% of package size.
