### PR TITLE
refactor(escape): use regex replace, remove Node < 4 polyfill

### DIFF
--- a/src/escape.ts
+++ b/src/escape.ts
@@ -6,24 +6,6 @@ const xmlCodeMap = new Map([
     [62, "&gt;"],
 ]);
 
-// For compatibility with node < 4, we wrap `codePointAt`
-/**
- * Read a code point at a given index.
- * @param input Input string to encode or decode.
- * @param index Current read position in the input string.
- */
-export const getCodePoint: (c: string, index: number) => number =
-    typeof String.prototype.codePointAt === "function"
-        ? (input: string, index: number): number => input.codePointAt(index)!
-        : // http://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-          (c: string, index: number): number =>
-              (c.charCodeAt(index) & 0xfc_00) === 0xd8_00
-                  ? (c.charCodeAt(index) - 0xd8_00) * 0x4_00 +
-                    c.charCodeAt(index + 1) -
-                    0xdc_00 +
-                    0x1_00_00
-                  : c.charCodeAt(index);
-
 /**
  * Bitset for ASCII characters that need to be escaped in XML.
  */
@@ -86,75 +68,67 @@ export function encodeXML(input: string): string {
 export const escape: typeof encodeXML = encodeXML;
 
 /**
- * Creates a function that escapes all characters matched by the given regular
- * expression using the given map of characters to escape to their entities.
- * @param regex Regular expression to match characters to escape.
- * @param map Map of characters to escape to their entities.
- * @returns Function that escapes all characters matched by the given regular
- * expression using the given map of characters to escape to their entities.
+ * Replacement callback used by {@link escapeUTF8}, {@link escapeAttribute},
+ * and {@link escapeText} to map specific characters to their XML/HTML
+ * entity representations.
+ *
+ * Converts `"`, `&`, `'`, `<`, `>`, and non-breaking space (`\u00A0`)
+ * to their corresponding entities; returns all other characters unchanged.
+ * @param c Single character match from the respective escape RegExp.
  */
-function getEscaper(
-    regex: RegExp,
-    map: Map<number, string>,
-): (data: string) => string {
-    return function escape(data: string): string {
-        let match: RegExpExecArray | null;
-        let lastIndex = 0;
-        let result = "";
-
-        while ((match = regex.exec(data))) {
-            if (lastIndex !== match.index) {
-                result += data.substring(lastIndex, match.index);
-            }
-
-            // We know that this character will be in the map.
-            result += map.get(match[0].charCodeAt(0))!;
-
-            // Every match will be of length 1
-            lastIndex = match.index + 1;
+function escapeReplacer(c: string): string {
+    switch (c) {
+        case '"': {
+            return "&quot;";
         }
-
-        return result + data.substring(lastIndex);
-    };
+        case "&": {
+            return "&amp;";
+        }
+        case "'": {
+            return "&apos;";
+        }
+        case "<": {
+            return "&lt;";
+        }
+        case ">": {
+            return "&gt;";
+        }
+        case "\u00A0": {
+            return "&nbsp;";
+        }
+    }
+    return c;
 }
 
+const xmlEscapeRegex = /["&'<>]/g;
 /**
  * Encodes all characters not valid in XML documents using XML entities.
  *
  * Note that the output will be character-set dependent.
  * @param data String to escape.
  */
-export const escapeUTF8: (data: string) => string = /* #__PURE__ */ getEscaper(
-    /["&'<>]/g,
-    xmlCodeMap,
-);
+export function escapeUTF8(data: string): string {
+    return data.replace(xmlEscapeRegex, escapeReplacer);
+}
+
+const attributeEscapeRegex = /["&\u00A0]/g;
 
 /**
  * Encodes all characters that have to be escaped in HTML attributes,
  * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
  * @param data String to escape.
  */
-export const escapeAttribute: (data: string) => string =
-    /* #__PURE__ */ getEscaper(
-        /["&\u00A0]/g,
-        new Map([
-            [34, "&quot;"],
-            [38, "&amp;"],
-            [160, "&nbsp;"],
-        ]),
-    );
+export function escapeAttribute(data: string): string {
+    return data.replace(attributeEscapeRegex, escapeReplacer);
+}
+
+const textEscapeRegex = /[&<>\u00A0]/g;
 
 /**
  * Encodes all characters that have to be escaped in HTML text,
  * following {@link https://html.spec.whatwg.org/multipage/parsing.html#escapingString}.
  * @param data String to escape.
  */
-export const escapeText: (data: string) => string = /* #__PURE__ */ getEscaper(
-    /[&<>\u00A0]/g,
-    new Map([
-        [38, "&amp;"],
-        [60, "&lt;"],
-        [62, "&gt;"],
-        [160, "&nbsp;"],
-    ]),
-);
+export function escapeText(data: string): string {
+    return data.replace(textEscapeRegex, escapeReplacer);
+}


### PR DESCRIPTION
## Summary

- Replaces the `getEscaper` factory pattern (manual `regex.exec` loop) with direct `String.prototype.replace` calls using a shared `escapeReplacer` switch function for `escapeUTF8`, `escapeAttribute`, and `escapeText`
- Removes the `getCodePoint` Node < 4 polyfill — uses native `String.prototype.codePointAt` directly
- Updates `encodeXML` and `encodeHTMLTrieRe` (in `encode.ts`) to call `codePointAt` instead of the removed `getCodePoint` wrapper

## Breaking changes

- **`getCodePoint` is no longer exported from `escape.ts`.** Any downstream code importing this helper will break. This was an internal/undocumented export.
- The `escapeUTF8`, `escapeAttribute`, and `escapeText` exports change from `const` arrow functions to named `function` declarations. This should not affect normal usage, but code relying on `.name` or identity checks may notice.
- Drops the Node < 4 `codePointAt` polyfill — Node < 4 is no longer supported.

## Benchmark results

Geometric mean across 12 text variants (short/medium/long × low/high entity density × named/numeric), via [html-entity-benchmarks](https://github.com/nicolo-ribaudo/html-entity-benchmarks) `compare`:

| | Geo mean (ops/s) |
|---|---|
| **entities v8** (published) | 2.23M |
| **escape-perf** | 1.81M |
| **Δ** | **−19%** |

`escapeUTF8` regresses on short inputs where the old `getEscaper` bitset loop was faster than `String.prototype.replace`. Longer inputs are closer to parity. The change is primarily a code simplification (−45 lines, −51% escape bundle size).

## Bundle size (esbuild --minify --tree-shaking, esm)

| Export | Before | After | Δ |
|---|---|---|---|
| `escapeUTF8` | 483 B (319 gz) | 238 B (162 gz) | **−51%** (−49% gz) |
| `encodeHTML` | 14,455 B (6,242 gz) | 14,273 B (6,153 gz) | −1% |
| Full bundle | 51,718 B (28,091 gz) | 51,483 B (27,969 gz) | −0.5% |

🤖 Generated with Claude Opus ([Claude Code](https://claude.com/claude-code))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal implementation of encoding and escaping utilities by removing intermediate helper functions and consolidating escape logic into dedicated function implementations.

* **Style**
  * Adjusted formatting in test type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->