### PR TITLE
fix(decode): fix legacy entities in attributes regression

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -68,6 +68,25 @@ describe("Decode test", () => {
         expect(entities.decodeHTMLAttribute("&notP")).toBe("&notP");
         expect(entities.decodeHTMLAttribute("&not3")).toBe("&not3");
     });
+
+    it("should not decode legacy entity in attribute mode when descended-into entity is interrupted (#2208)", () => {
+        /*
+         * After &not is matched as a legacy entity, descending into &notin
+         * means the next char (`i`) is alphanumeric, which per the HTML spec
+         * invalidates the legacy match in attribute mode.
+         */
+        expect(
+            entities.decodeHTML("&notin\0;", entities.DecodingMode.Attribute),
+        ).toBe("&notin\0;");
+
+        expect(entities.decodeHTMLAttribute("&notin\0;")).toBe("&notin\0;");
+
+        /*
+         * Same condition with a non-alphanumeric interrupter that would
+         * otherwise pass `isEntityInAttributeInvalidEnd`.
+         */
+        expect(entities.decodeHTMLAttribute("&notin<")).toBe("&notin<");
+    });
 });
 
 describe("EntityDecoder", () => {
@@ -149,6 +168,23 @@ describe("EntityDecoder", () => {
     it("should not fail if nothing is written", () => {
         expect(decoder.end()).toBe(0);
         expect(callback).toHaveBeenCalledTimes(0);
+    });
+
+    it("should not commit a legacy match in attribute mode after descending past it (#2208)", () => {
+        decoder.startEntity(entities.DecodingMode.Attribute);
+        expect(decoder.write("notin\0;", 0)).toBe(0);
+        expect(decoder.end()).toBe(0);
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should not commit a legacy match in attribute mode after descending past it across chunks (#2208)", () => {
+        decoder.startEntity(entities.DecodingMode.Attribute);
+        for (const chunk of ["no", "ti", "n\0", ";"]) {
+            const written = decoder.write(chunk, 0);
+            expect(written).toBeLessThanOrEqual(0);
+        }
+        expect(decoder.end()).toBe(0);
+        expect(callback).not.toHaveBeenCalled();
     });
 
     /*

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -393,6 +393,12 @@ export class EntityDecoder {
                     (this.decodeMode === DecodingMode.Attribute &&
                         // We shouldn't have consumed any characters after the entity,
                         (valueLength === 0 ||
+                            /*
+                             * We shouldn't have descended past the legacy match
+                             * (any character descended past is alphanumeric and
+                             * would invalidate the legacy match per the spec).
+                             */
+                            this.excess > 1 ||
                             // And there should be no invalid characters.
                             isEntityInAttributeInvalidEnd(char)))
                     ? 0


### PR DESCRIPTION
Fixes https://github.com/fb55/entities/issues/2208

From the added test:

> After `&not` is matched as a legacy entity, descending into `&notin` means the next char (`i`) is alphanumeric, which per the HTML spec invalidates the legacy match in attribute mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved named-entity decoding in attributes to correctly handle edge cases with null bytes and multi-chunk data.

* **Tests**
  * Added regression tests for named-entity decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->