### PR TITLE
perf(escape): faster encodeXML and escape helpers

### DIFF
--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -3,12 +3,66 @@ import * as entities from "./index.js";
 
 describe("escape HTML", () => {
     it("should escape HTML attribute values", () =>
-        expect(entities.escapeAttribute('<a " attr > & value \u00A0!')).toBe(
+        expect(entities.escapeAttribute('<a " attr > & value  !')).toBe(
             "<a &quot; attr > &amp; value &nbsp;!",
         ));
 
     it("should escape HTML text", () =>
-        expect(entities.escapeText('<a " text > & value \u00A0!')).toBe(
+        expect(entities.escapeText('<a " text > & value  !')).toBe(
             '&lt;a " text &gt; &amp; value &nbsp;!',
         ));
+});
+
+describe("encodeXML scan", () => {
+    it("should escape characters found via the regex fallback", () => {
+        /*
+         * A clean run longer than the 32-char inline window forces the regex
+         * path, for both an ASCII special and a non-ASCII character.
+         */
+        const span = "a".repeat(64);
+        expect(entities.encodeXML(`${span}&${span}`)).toBe(
+            `${span}&amp;${span}`,
+        );
+        expect(entities.encodeXML(`${span}ü`)).toBe(`${span}&#252;`);
+    });
+
+    it("should encode surrogate pairs, including via the regex fallback", () => {
+        // The trailing surrogate is skipped; the code point comes from the pair.
+        expect(entities.encodeXML("x😀x")).toBe("x&#128512;x");
+        expect(entities.encodeXML("😀🐊")).toBe("&#128512;&#128010;");
+        // Pair located by the regex (after a clean span past the window).
+        const span = "a".repeat(40);
+        expect(entities.encodeXML(`${span}😀`)).toBe(`${span}&#128512;`);
+    });
+
+    it("should encode lone surrogates by code unit", () => {
+        /*
+         * The regex has no `u` flag, so unpaired surrogates match and encode
+         * as their bare unit value (codePointAt returns the surrogate itself).
+         */
+        expect(entities.encodeXML("a\uD83Db")).toBe("a&#55357;b");
+        expect(entities.encodeXML("a\uDE00b")).toBe("a&#56832;b");
+        expect(entities.encodeXML(`${"a".repeat(40)}\uD83D`)).toBe(
+            `${"a".repeat(40)}&#55357;`,
+        );
+    });
+});
+
+describe("escape helpers (shared exec loop)", () => {
+    it("should return the input unchanged when nothing matches", () => {
+        /*
+         * The match-free early return; the helpers are not otherwise
+         * exercised with input that produces no match.
+         */
+        expect(entities.escapeUTF8("no specials")).toBe("no specials");
+        expect(entities.escapeText("no specials")).toBe("no specials");
+    });
+
+    it("should escape `'` via escapeUTF8", () => {
+        /*
+         * The apostrophe arm of the shared dispatch is reachable only through
+         * escapeUTF8, whose set is the only one including `'`.
+         */
+        expect(entities.escapeUTF8("&&a''")).toBe("&amp;&amp;a&apos;&apos;");
+    });
 });

--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -12,3 +12,72 @@ describe("escape HTML", () => {
             '&lt;a " text &gt; &amp; value &nbsp;!',
         ));
 });
+
+describe("encodeXML scan", () => {
+    it("should return clean input unchanged", () => {
+        // Nothing escapable: the window runs clean to the end, firing the identity return.
+        expect(entities.encodeXML("abc123")).toBe("abc123");
+        expect(entities.encodeXML("simple text")).toBe("simple text");
+    });
+
+    it("should escape adjacent specials", () => {
+        // Consecutive matches: each special is escaped without a scan jump.
+        expect(entities.encodeXML("&&")).toBe("&amp;&amp;");
+        expect(entities.encodeXML("<>")).toBe("&lt;&gt;");
+        expect(entities.encodeXML(`'"`)).toBe("&apos;&quot;");
+    });
+
+    it("should escape characters found via the regex fallback", () => {
+        /*
+         * A clean run longer than the 32-char inline window forces the regex
+         * path, for both an ASCII special and a non-ASCII character.
+         */
+        const span = "a".repeat(64);
+        expect(entities.encodeXML(`${span}&${span}`)).toBe(
+            `${span}&amp;${span}`,
+        );
+        expect(entities.encodeXML(`${span}ü`)).toBe(`${span}&#252;`);
+    });
+
+    it("should encode surrogate pairs, including via the regex fallback", () => {
+        // The trailing surrogate is skipped; the code point comes from the pair.
+        expect(entities.encodeXML("x😀x")).toBe("x&#128512;x");
+        expect(entities.encodeXML("😀🐊")).toBe("&#128512;&#128010;");
+        // Pair located by the regex (after a clean span past the window).
+        const span = "a".repeat(40);
+        expect(entities.encodeXML(`${span}😀`)).toBe(`${span}&#128512;`);
+    });
+
+    it("should encode lone surrogates by code unit", () => {
+        /*
+         * The regex has no `u` flag, so unpaired surrogates match and encode
+         * as their bare unit value (codePointAt returns the surrogate itself).
+         */
+        expect(entities.encodeXML("a\u{D83D}b")).toBe("a&#55357;b");
+        expect(entities.encodeXML("a\u{DE00}b")).toBe("a&#56832;b");
+        const prefix = "a".repeat(40);
+        const loneSurrogate = String.fromCharCode(0xd8_3d);
+        expect(entities.encodeXML(`${prefix}${loneSurrogate}`)).toBe(
+            `${prefix}&#55357;`,
+        );
+    });
+});
+
+describe("escape helpers (shared exec loop)", () => {
+    it("should return the input unchanged when nothing matches", () => {
+        /*
+         * The match-free early return; the helpers are not otherwise
+         * exercised with input that produces no match.
+         */
+        expect(entities.escapeUTF8("no specials")).toBe("no specials");
+        expect(entities.escapeText("no specials")).toBe("no specials");
+    });
+
+    it("should escape `'` via escapeUTF8", () => {
+        /*
+         * The apostrophe arm of the shared dispatch is reachable only through
+         * escapeUTF8, whose set is the only one including `'`.
+         */
+        expect(entities.escapeUTF8("&&a''")).toBe("&amp;&amp;a&apos;&apos;");
+    });
+});

--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -97,10 +97,12 @@ describe("escape helpers (shared exec loop)", () => {
 
     it("should reset regex state between repeated calls", () => {
         /*
-         * The shared `/g` regexes are module-level, so `escapeWithRegex` must
-         * reset `lastIndex` on entry. Each helper is called first with a match
-         * near the end, then with a match at the start: a leaked `lastIndex`
-         * would make the second call miss the early match and return it raw.
+         * The shared `/g` regexes are module-level. `escapeWithRegex` runs
+         * `exec` until it returns null (which resets `lastIndex` to 0), so
+         * repeated calls stay correct; this pins that contract by calling each
+         * helper twice — a match near the end, then one at the start. (The
+         * riskier `encodeXML` path, which sets `lastIndex` manually and can
+         * leave it non-zero, is covered separately above.)
          */
         expect(entities.escapeUTF8("aaaaaaaaaa&")).toBe("aaaaaaaaaa&amp;");
         expect(entities.escapeUTF8("&")).toBe("&amp;");

--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -61,6 +61,20 @@ describe("encodeXML scan", () => {
             `${prefix}&#55357;`,
         );
     });
+
+    it("should not leak regex lastIndex between calls", () => {
+        /*
+         * `encodeXML` drives the module-level `xmlEncodeRegex` and sets its
+         * `lastIndex` before every `exec`. A stale value from a prior call
+         * (here a longer input) must not make the next call's regex jump skip
+         * past an earlier special. Ordered long-then-short so a leaked index
+         * would land beyond the `&` and drop it.
+         */
+        const long = "a".repeat(100);
+        expect(entities.encodeXML(`${long}&`)).toBe(`${long}&amp;`);
+        const short = "a".repeat(40);
+        expect(entities.encodeXML(`${short}&`)).toBe(`${short}&amp;`);
+    });
 });
 
 describe("escape helpers (shared exec loop)", () => {
@@ -79,5 +93,22 @@ describe("escape helpers (shared exec loop)", () => {
          * escapeUTF8, whose set is the only one including `'`.
          */
         expect(entities.escapeUTF8("&&a''")).toBe("&amp;&amp;a&apos;&apos;");
+    });
+
+    it("should reset regex state between repeated calls", () => {
+        /*
+         * The shared `/g` regexes are module-level, so `escapeWithRegex` must
+         * reset `lastIndex` on entry. Each helper is called first with a match
+         * near the end, then with a match at the start: a leaked `lastIndex`
+         * would make the second call miss the early match and return it raw.
+         */
+        expect(entities.escapeUTF8("aaaaaaaaaa&")).toBe("aaaaaaaaaa&amp;");
+        expect(entities.escapeUTF8("&")).toBe("&amp;");
+        expect(entities.escapeAttribute('aaaaaaaaaa"')).toBe(
+            "aaaaaaaaaa&quot;",
+        );
+        expect(entities.escapeAttribute('"')).toBe("&quot;");
+        expect(entities.escapeText("aaaaaaaaaa<")).toBe("aaaaaaaaaa&lt;");
+        expect(entities.escapeText("<")).toBe("&lt;");
     });
 });

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -11,27 +11,62 @@ const xmlCodeMap = new Map([
  */
 export const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34 ("),38 (&),39 ('),60 (<),62 (>)
 
+/*
+ * Matches exactly the characters `encodeXML` escapes: the five XML special
+ * characters plus every non-ASCII code unit (lone surrogates included — no
+ * `u` flag). Kept in sync with `XML_BITSET_VALUE`.
+ */
+const xmlEncodeRegex = /["&'<>\u0080-\uFFFF]/g;
+
 /**
  * Encodes all non-ASCII characters, as well as characters not valid in XML
- * documents using XML entities. Uses a fast bitset scan instead of RegExp.
+ * documents using XML entities.
  *
  * If a character has no equivalent entity, a numeric decimal reference
  * (eg. `&#252;`) will be used.
  * @param input Input string to encode or decode.
  */
 export function encodeXML(input: string): string {
+    const { length } = input;
     let out: string | undefined;
     let last = 0;
-    const { length } = input;
+    let index = 0;
 
-    for (let index = 0; index < length; index++) {
+    while (index < length) {
         const char = input.charCodeAt(index);
 
-        // Check for ASCII chars that don't need escaping
+        /*
+         * Find the next character to escape: scan a short window inline
+         * (escapable characters cluster in markup-heavy input), then fall
+         * back to the regex, which skips clean spans in native code.
+         */
         if (
             char < 0x80 &&
             (((XML_BITSET_VALUE >>> char) & 1) === 0 || char >= 64 || char < 32)
         ) {
+            const bound = Math.min(index + 32, length);
+            let next = index + 1;
+            while (next < bound) {
+                const code = input.charCodeAt(next);
+                if (
+                    code >= 0x80 ||
+                    (((XML_BITSET_VALUE >>> code) & 1) === 1 &&
+                        code < 64 &&
+                        code >= 32)
+                ) {
+                    break;
+                }
+                next++;
+            }
+            if (next < bound) {
+                index = next;
+                continue;
+            }
+            if (next >= length) break;
+            xmlEncodeRegex.lastIndex = next;
+            const match = xmlEncodeRegex.exec(input);
+            if (match === null) break;
+            ({ index } = match);
             continue;
         }
 
@@ -41,7 +76,7 @@ export function encodeXML(input: string): string {
         if (char < 64) {
             // Known replacement
             out += xmlCodeMap.get(char)!;
-            last = index + 1;
+            last = index += 1;
             continue;
         }
 
@@ -49,7 +84,7 @@ export function encodeXML(input: string): string {
         const cp = input.codePointAt(index)!;
         out += `&#${cp};`;
         if (cp !== char) index++; // Skip trailing surrogate
-        last = index + 1;
+        last = index += 1;
     }
 
     if (out === undefined) return input;
@@ -68,36 +103,39 @@ export function encodeXML(input: string): string {
 export const escape: typeof encodeXML = encodeXML;
 
 /**
- * Replacement callback used by {@link escapeUTF8}, {@link escapeAttribute},
- * and {@link escapeText} to map specific characters to their XML/HTML
- * entity representations.
- *
- * Converts `"`, `&`, `'`, `<`, `>`, and non-breaking space (`\u00A0`)
- * to their corresponding entities; returns all other characters unchanged.
- * @param c Single character match from the respective escape RegExp.
+ * Escape `data` using `re`, mapping each matched character to its entity.
+ * @param re Global regex matching exactly the characters to escape
+ *   (`"`, `&`, `'`, `<`, `>`, `\u00A0` at most).
+ * @param data String to escape.
  */
-function escapeReplacer(c: string): string {
-    switch (c) {
-        case '"': {
-            return "&quot;";
-        }
-        case "&": {
-            return "&amp;";
-        }
-        case "'": {
-            return "&apos;";
-        }
-        case "<": {
-            return "&lt;";
-        }
-        case ">": {
-            return "&gt;";
-        }
-        case "\u00A0": {
-            return "&nbsp;";
-        }
-    }
-    return c;
+function escapeWithRegex(re: RegExp, data: string): string {
+    re.lastIndex = 0;
+    let match = re.exec(data);
+    if (match === null) return data;
+
+    let out = "";
+    let last = 0;
+    do {
+        const { index } = match;
+        if (last !== index) out += data.substring(last, index);
+        const char = data.charCodeAt(index);
+        out +=
+            char === 34
+                ? "&quot;"
+                : char === 38
+                  ? "&amp;"
+                  : char === 39
+                    ? "&apos;"
+                    : char === 60
+                      ? "&lt;"
+                      : char === 62
+                        ? "&gt;"
+                        : "&nbsp;";
+        last = index + 1;
+        match = re.exec(data);
+    } while (match !== null);
+
+    return out + data.substring(last);
 }
 
 const xmlEscapeRegex = /["&'<>]/g;
@@ -108,7 +146,7 @@ const xmlEscapeRegex = /["&'<>]/g;
  * @param data String to escape.
  */
 export function escapeUTF8(data: string): string {
-    return data.replace(xmlEscapeRegex, escapeReplacer);
+    return escapeWithRegex(xmlEscapeRegex, data);
 }
 
 const attributeEscapeRegex = /["&\u00A0]/g;
@@ -119,7 +157,7 @@ const attributeEscapeRegex = /["&\u00A0]/g;
  * @param data String to escape.
  */
 export function escapeAttribute(data: string): string {
-    return data.replace(attributeEscapeRegex, escapeReplacer);
+    return escapeWithRegex(attributeEscapeRegex, data);
 }
 
 const textEscapeRegex = /[&<>\u00A0]/g;
@@ -130,5 +168,5 @@ const textEscapeRegex = /[&<>\u00A0]/g;
  * @param data String to escape.
  */
 export function escapeText(data: string): string {
-    return data.replace(textEscapeRegex, escapeReplacer);
+    return escapeWithRegex(textEscapeRegex, data);
 }

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -11,27 +11,64 @@ const xmlCodeMap = new Map([
  */
 export const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34 ("),38 (&),39 ('),60 (<),62 (>)
 
+/*
+ * Matches exactly the characters `encodeXML` escapes: the five XML special
+ * characters plus every non-ASCII code unit (lone surrogates included — no
+ * `u` flag). Kept in sync with `XML_BITSET_VALUE`.
+ */
+// eslint-disable-next-line unicorn/prefer-unicode-code-point-escapes -- the `\u{\u2026}` form requires the `u` flag, which we deliberately omit so lone surrogates match by code unit
+const xmlEncodeRegex = /["&'<>\u0080-\uFFFF]/g;
+
+/**
+ * Whether `code` (a UTF-16 code unit) is escaped by {@link encodeXML}: a
+ * non-ASCII unit, or one of the five XML specials flagged in
+ * `XML_BITSET_VALUE` (which is only meaningful for code units 32\u201363).
+ * @param code Code unit to test.
+ */
+function isXmlEscapable(code: number): boolean {
+    return (
+        code >= 0x80 ||
+        (code >= 32 && code < 64 && ((XML_BITSET_VALUE >>> code) & 1) === 1)
+    );
+}
+
 /**
  * Encodes all non-ASCII characters, as well as characters not valid in XML
- * documents using XML entities. Uses a fast bitset scan instead of RegExp.
+ * documents using XML entities.
  *
  * If a character has no equivalent entity, a numeric decimal reference
  * (eg. `&#252;`) will be used.
  * @param input Input string to encode or decode.
  */
 export function encodeXML(input: string): string {
+    const { length } = input;
     let out: string | undefined;
     let last = 0;
-    const { length } = input;
+    let index = 0;
 
-    for (let index = 0; index < length; index++) {
+    while (index < length) {
         const char = input.charCodeAt(index);
 
-        // Check for ASCII chars that don't need escaping
-        if (
-            char < 0x80 &&
-            (((XML_BITSET_VALUE >>> char) & 1) === 0 || char >= 64 || char < 32)
-        ) {
+        /*
+         * Find the next character to escape: scan a short window inline
+         * (escapable characters cluster in markup-heavy input), then fall
+         * back to the regex, which skips clean spans in native code.
+         */
+        if (!isXmlEscapable(char)) {
+            const bound = Math.min(index + 32, length);
+            let next = index + 1;
+            while (next < bound && !isXmlEscapable(input.charCodeAt(next))) {
+                next++;
+            }
+            if (next < bound) {
+                index = next;
+                continue;
+            }
+            if (next >= length) break;
+            xmlEncodeRegex.lastIndex = next;
+            const match = xmlEncodeRegex.exec(input);
+            if (match === null) break;
+            ({ index } = match);
             continue;
         }
 
@@ -41,7 +78,7 @@ export function encodeXML(input: string): string {
         if (char < 64) {
             // Known replacement
             out += xmlCodeMap.get(char)!;
-            last = index + 1;
+            last = index += 1;
             continue;
         }
 
@@ -49,7 +86,7 @@ export function encodeXML(input: string): string {
         const cp = input.codePointAt(index)!;
         out += `&#${cp};`;
         if (cp !== char) index++; // Skip trailing surrogate
-        last = index + 1;
+        last = index += 1;
     }
 
     if (out === undefined) return input;
@@ -68,36 +105,39 @@ export function encodeXML(input: string): string {
 export const escape: typeof encodeXML = encodeXML;
 
 /**
- * Replacement callback used by {@link escapeUTF8}, {@link escapeAttribute},
- * and {@link escapeText} to map specific characters to their XML/HTML
- * entity representations.
- *
- * Converts `"`, `&`, `'`, `<`, `>`, and non-breaking space (`\u00A0`)
- * to their corresponding entities; returns all other characters unchanged.
- * @param c Single character match from the respective escape RegExp.
+ * Escape `data` using `re`, mapping each matched character to its entity.
+ * @param re Global regex matching exactly the characters to escape
+ *   (`"`, `&`, `'`, `<`, `>`, `\u00A0` at most).
+ * @param data String to escape.
  */
-function escapeReplacer(c: string): string {
-    switch (c) {
-        case '"': {
-            return "&quot;";
-        }
-        case "&": {
-            return "&amp;";
-        }
-        case "'": {
-            return "&apos;";
-        }
-        case "<": {
-            return "&lt;";
-        }
-        case ">": {
-            return "&gt;";
-        }
-        case "\u{A0}": {
-            return "&nbsp;";
-        }
-    }
-    return c;
+function escapeWithRegex(re: RegExp, data: string): string {
+    re.lastIndex = 0;
+    let match = re.exec(data);
+    if (match === null) return data;
+
+    let out = "";
+    let last = 0;
+    do {
+        const { index } = match;
+        if (last !== index) out += data.substring(last, index);
+        const char = data.charCodeAt(index);
+        out +=
+            char === 34
+                ? "&quot;"
+                : char === 38
+                  ? "&amp;"
+                  : char === 39
+                    ? "&apos;"
+                    : char === 60
+                      ? "&lt;"
+                      : char === 62
+                        ? "&gt;"
+                        : "&nbsp;";
+        last = index + 1;
+        match = re.exec(data);
+    } while (match !== null);
+
+    return out + data.substring(last);
 }
 
 const xmlEscapeRegex = /["&'<>]/g;
@@ -108,8 +148,7 @@ const xmlEscapeRegex = /["&'<>]/g;
  * @param data String to escape.
  */
 export function escapeUTF8(data: string): string {
-    // eslint-disable-next-line unicorn/no-unsafe-string-replacement -- `escapeReplacer` is a function replacer; `$` substitution does not apply
-    return data.replace(xmlEscapeRegex, escapeReplacer);
+    return escapeWithRegex(xmlEscapeRegex, data);
 }
 
 const attributeEscapeRegex = /["&\u{A0}]/gu;
@@ -120,8 +159,7 @@ const attributeEscapeRegex = /["&\u{A0}]/gu;
  * @param data String to escape.
  */
 export function escapeAttribute(data: string): string {
-    // eslint-disable-next-line unicorn/no-unsafe-string-replacement -- `escapeReplacer` is a function replacer; `$` substitution does not apply
-    return data.replace(attributeEscapeRegex, escapeReplacer);
+    return escapeWithRegex(attributeEscapeRegex, data);
 }
 
 const textEscapeRegex = /[&<>\u{A0}]/gu;
@@ -132,6 +170,5 @@ const textEscapeRegex = /[&<>\u{A0}]/gu;
  * @param data String to escape.
  */
 export function escapeText(data: string): string {
-    // eslint-disable-next-line unicorn/no-unsafe-string-replacement -- `escapeReplacer` is a function replacer; `$` substitution does not apply
-    return data.replace(textEscapeRegex, escapeReplacer);
+    return escapeWithRegex(textEscapeRegex, data);
 }


### PR DESCRIPTION
Speed up the small escape imports (`src/escape.ts` only):

- `encodeXML`: short inline bitset window, then a regex skips clean spans in native code.
- `escapeUTF8`/`escapeAttribute`/`escapeText`: shared manual `exec` loop instead of replace-with-callback.

html-entity-benchmarks (one process per variant, best of 5): escape geo mean 2.03M → 2.73M ops/s (+35%), all 12 text variants faster (+8% to +90%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked XML/HTML escaping to use regex-driven scanning with faster skip-ahead, with correct handling of supplementary characters and trailing/unpaired surrogates while keeping the same public behavior.
  * Centralized escaping logic into a shared regex exec loop used by the existing escape helpers.
* **Bug Fixes / Behavior**
  * Ensures `\u00A0` is encoded as `&nbsp;` for both attribute and text escaping.
* **Tests**
  * Added `encodeXML` scan coverage for no-op cases, adjacent escapable characters, long-span fallback behavior, surrogate pairs, and lone surrogates.
  * Added tests for the shared escaping helper behavior via `escapeUTF8`/`escapeText`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->