### PR TITLE
fix: do not over-consume a streaming legacy compact-run entity

### DIFF
--- a/src/decode-stream.spec.ts
+++ b/src/decode-stream.spec.ts
@@ -43,6 +43,20 @@ describe("EntityDecoder Streaming", () => {
         expect(callback).toHaveBeenCalledWith(8755, 33);
     });
 
+    it("should not over-consume a legacy compact-run entity (e.g. `&Egrave`)", () => {
+        const callback = vi.fn();
+        const decoder = new EntityDecoder(htmlDecodeTree, callback);
+
+        // `&Egrave` is a legacy (semicolon-optional) entity stored as a
+        // compact run. When it is terminated by the next character, only
+        // its 7 characters (`&Egrave`) should be consumed -- the following
+        // `&` must remain available to start the next entity.
+        decoder.startEntity(DecodingMode.Legacy);
+
+        expect(decoder.write("&Egrave&CHcy", 1)).toBe(7);
+        expect(callback).toHaveBeenCalledWith(0xc8, 7); // È
+    });
+
     it("should decode xml entities (single chunk)", () => {
         const callback = vi.fn();
         const decoder = new EntityDecoder(xmlDecodeTree, callback);

--- a/src/decode-stream.spec.ts
+++ b/src/decode-stream.spec.ts
@@ -47,10 +47,12 @@ describe("EntityDecoder Streaming", () => {
         const callback = vi.fn();
         const decoder = new EntityDecoder(htmlDecodeTree, callback);
 
-        // `&Egrave` is a legacy (semicolon-optional) entity stored as a
-        // compact run. When it is terminated by the next character, only
-        // its 7 characters (`&Egrave`) should be consumed -- the following
-        // `&` must remain available to start the next entity.
+        /*
+         * The `&Egrave` string is a legacy (semicolon-optional) entity stored
+         * as a compact run. When it is terminated by the next character, only
+         * its 7 characters (`&Egrave`) should be consumed -- the following `&`
+         * must remain available to start the next entity.
+         */
         decoder.startEntity(DecodingMode.Legacy);
 
         expect(decoder.write("&Egrave&CHcy", 1)).toBe(7);

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -383,9 +383,11 @@ export class EntityDecoder {
                     (current & BinTrieFlags.FLAG13) === 0
                 ) {
                     this.result = this.treeIndex;
-                    // `excess` started at 1 to count the leading `&`, which is
-                    // already in `consumed`; subtract it so the run's
-                    // characters are not counted twice.
+                    /*
+                     * The `excess` counter started at 1 to count the leading
+                     * `&`, which is already in `consumed`; subtract it so the
+                     * run's characters are not counted twice.
+                     */
                     this.consumed += this.excess - 1;
                     this.excess = 1;
                 }

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -383,8 +383,11 @@ export class EntityDecoder {
                     (current & BinTrieFlags.FLAG13) === 0
                 ) {
                     this.result = this.treeIndex;
-                    this.consumed += this.excess;
-                    this.excess = 0;
+                    // `excess` started at 1 to count the leading `&`, which is
+                    // already in `consumed`; subtract it so the run's
+                    // characters are not counted twice.
+                    this.consumed += this.excess - 1;
+                    this.excess = 1;
                 }
             }
 


### PR DESCRIPTION
The streaming \`EntityDecoder\` (the resumable API htmlparser2/parse5 use) reported \`consumed\` one too high when matching a legacy, semicolon-less named entity stored as a compact run in the trie. The over-count makes the caller skip the character right after the entity, swallowing the following \`&\` or a literal char.

## Repro

\`\`\`js
const decoder = new EntityDecoder(htmlDecodeTree, cb);
decoder.startEntity(DecodingMode.Legacy);
decoder.write("&Egrave&CHcy", 1); // returns 8, should be 7 ("&Egrave" is 7 chars)
\`\`\`

Streamed through \`decodeHTML\`, \`"&Egrave&CHcy"\` becomes \`"ÈCHcy"\` (the \`&\` is lost) instead of \`"È&CHcy"\`.

## Why

In the compact-run match block, \`excess\` starts at 1 to count the leading \`&\` (already included in \`consumed\`), so \`consumed += excess\` counts the \`&\` twice. Subtracting 1 mirrors the net effect of the non-run path, which is already correct.

The batch \`decodeHTML\`/\`decodeWithTrie\` path and published \`entities@8.0.0\` already return the correct count; browser \`DOMParser\` agrees. Only the resumable streaming class was affected, for the 37 of 106 legacy entities stored as long compact runs (\`AElig\`, \`Aacute\`, \`Egrave\`, \`szlig\`, ... and their lowercase forms).

## Tests

Added a streaming regression test (\`&Egrave\` consumes 7, callback gets \`(0xc8, 7)\`). Verified red before / green after; full suite of 302 passes, and the 55k-case differential against published 8.0.0 drops to 0 mismatches. The fix is in the runtime decode logic only; no generated trie data changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy named-entity decoding so consumed character counts remain accurate during streaming parsing, preventing off-by-one miscalculations in certain legacy entity scenarios.

* **Tests**
  * Added coverage for legacy compact-run entity handling in streaming decode mode, verifying correct consumption length and decoded code point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->