### PR TITLE
fix(escape): restore deprecated getCodePoint export

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,9 @@ export default defineConfig([
                 },
             ],
             "n/no-unpublished-import": 0,
+            // Conflicts with biome's lint/style/useNumberNamespace, which
+            // prefers `Number.NaN`; eslint-config-biome doesn't cover it yet.
+            "unicorn/prefer-global-number-constants": 0,
         },
     },
     {

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -28,7 +28,6 @@ function makeStreamingImpl(chunkSize: number) {
             const entityStart = offset + 1;
             let length: number;
 
-            // eslint-disable-next-line unicorn/prefer-global-number-constants -- biome's useNumberNamespace enforces `Number.POSITIVE_INFINITY`
             if (chunkSize === Number.POSITIVE_INFINITY) {
                 length = decoder.write(input, entityStart);
             } else {
@@ -90,7 +89,6 @@ const syncImpl: DecoderImpl = {
 
 const implementations: [string, DecoderImpl][] = [
     ["sync", syncImpl],
-    // eslint-disable-next-line unicorn/prefer-global-number-constants -- biome's useNumberNamespace enforces `Number.POSITIVE_INFINITY`
     ["streaming (all at once)", makeStreamingImpl(Number.POSITIVE_INFINITY)],
     ["streaming (char-by-char)", makeStreamingImpl(1)],
 ];

--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getCodePoint } from "./escape.js";
 import * as entities from "./index.js";
 
 describe("escape HTML", () => {
@@ -11,6 +12,22 @@ describe("escape HTML", () => {
         expect(entities.escapeText('<a " text > & value \u{A0}!')).toBe(
             '&lt;a " text &gt; &amp; value &nbsp;!',
         ));
+});
+
+describe("getCodePoint", () => {
+    it("should be exported as a function", () =>
+        expect(typeof getCodePoint).toBe("function"));
+
+    it("should read BMP code points", () => {
+        expect(getCodePoint("abc", 0)).toBe(97);
+        expect(getCodePoint("abc", 2)).toBe(99);
+        expect(getCodePoint("ü", 0)).toBe(0xfc);
+    });
+
+    it("should read astral code points from surrogate pairs", () => {
+        expect(getCodePoint("💯", 0)).toBe(128_175);
+        expect(getCodePoint("a\u{1F4A9}", 1)).toBe(0x1_f4_a9);
+    });
 });
 
 describe("encodeXML scan", () => {

--- a/src/escape.spec.ts
+++ b/src/escape.spec.ts
@@ -28,6 +28,11 @@ describe("getCodePoint", () => {
         expect(getCodePoint("💯", 0)).toBe(128_175);
         expect(getCodePoint("a\u{1F4A9}", 1)).toBe(0x1_f4_a9);
     });
+
+    it("should return NaN for out-of-range indices", () => {
+        expect(getCodePoint("abc", 3)).toBeNaN();
+        expect(getCodePoint("", 0)).toBeNaN();
+    });
 });
 
 describe("encodeXML scan", () => {

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -7,6 +7,18 @@ const xmlCodeMap = new Map([
 ]);
 
 /**
+ * Read a code point at a given index.
+ * @param input Input string to encode or decode.
+ * @param index Current read position in the input string.
+ * @deprecated Use `String.prototype.codePointAt` directly instead; this export
+ *   will be removed in the next major.
+ */
+export const getCodePoint: (c: string, index: number) => number = (
+    input: string,
+    index: number,
+): number => input.codePointAt(index)!;
+
+/**
  * Bitset for ASCII characters that need to be escaped in XML.
  */
 export const XML_BITSET_VALUE = 0x50_00_00_c4; // 32..63 -> 34 ("),38 (&),39 ('),60 (<),62 (>)

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -17,7 +17,7 @@ const xmlCodeMap = new Map([
 export const getCodePoint: (input: string, index: number) => number = (
     input: string,
     index: number,
-): number => input.codePointAt(index) ?? NaN;
+): number => input.codePointAt(index) ?? Number.NaN;
 
 /**
  * Bitset for ASCII characters that need to be escaped in XML.

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -8,15 +8,16 @@ const xmlCodeMap = new Map([
 
 /**
  * Read a code point at a given index.
- * @param input Input string to encode or decode.
+ * @param input String to read the code point from.
  * @param index Current read position in the input string.
+ * @returns The code point at `index`, or `NaN` if `index` is out of range.
  * @deprecated Use `String.prototype.codePointAt` directly instead; this export
  *   will be removed in the next major.
  */
-export const getCodePoint: (c: string, index: number) => number = (
+export const getCodePoint: (input: string, index: number) => number = (
     input: string,
     index: number,
-): number => input.codePointAt(index)!;
+): number => input.codePointAt(index) ?? NaN;
 
 /**
  * Bitset for ASCII characters that need to be escaped in XML.


### PR DESCRIPTION
## Why

`getCodePoint` was a public export of `entities/escape` in v8.0.0. It was removed on `main` by #2197, which is still unreleased. If 8.1.0 shipped without it, the release would remove a public API in a minor version, violating semver.

## What

- Re-adds `getCodePoint` to `src/escape.ts` with the same signature as v8.0.0 (`(c: string, index: number) => number`), implemented directly via `String.prototype.codePointAt` — the Node < 4 polyfill branch is no longer needed since the package requires Node >= 20.
- Marks it `@deprecated`, pointing users at `String.prototype.codePointAt`; the export will be removed in the next major.
- Matches v8.0.0's export surface: exposed from the `escape` module only (it was never re-exported from the package root).
- Adds a small spec covering BMP and astral code points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deprecated `getCodePoint(input, index)` helper for reading Unicode code points from strings (including characters outside the basic multilingual plane), with `NaN` returned when the index is out of range.
* **Tests**
  * Added a focused test suite covering BMP characters, surrogate-pair/astral characters, explicit surrogate-pair scenarios, and `NaN` behavior for invalid indices (including empty input).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->