### PR TITLE
ci: test minimum supported Node 20, drop EOL Node 16 from gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,7 +6,7 @@ on:
 
 env:
     FORCE_COLOR: 2
-    NODE: 16
+    NODE: lts/*
 
 permissions:
     contents: read

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -33,6 +33,7 @@ jobs:
             fail-fast: false
             matrix:
                 node:
+                    - 20
                     - 22
                     - 24
                     - lts/*

--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -33,10 +33,10 @@ jobs:
             fail-fast: false
             matrix:
                 node:
-                    - 20
-                    - 22
-                    - 24
-                    - lts/*
+                    - '20.19.0'
+                    - '22'
+                    - '24'
+                    - 'lts/*'
 
         steps:
             - uses: actions/checkout@v7


### PR DESCRIPTION
- `nodejs-test.yml`: `engines` declares `>=20.19.0`, but the test matrix only covered 22, 24, and `lts/*` — the minimum supported major was never tested. Adds `20` to the matrix (vitest 4 supports `^20.0.0`, so the toolchain runs fine there).
- `gh-pages.yml`: was pinned to EOL Node 16, while typedoc and the `engines` range require newer Node. Now uses `lts/*`.

Other workflows (publish, codeql, dependabot-automerge) already use `lts/*` or don't set up Node, so they're untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use the latest supported Node.js release line (instead of a fixed Node.js version).
  * Expanded the test workflow’s Node.js matrix to include an additional pinned version, increasing compatibility coverage across multiple Node releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->