### PR TITLE
docs: fix incorrect documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ import * as entities from "entities";
 
 // Encoding
 entities.escapeUTF8("&#38; ü"); // "&amp;#38; ü"
-entities.encodeXML("&#38; ü"); // "&amp;#38; &#xfc;"
+entities.encodeXML("&#38; ü"); // "&amp;#38; &#252;"
 entities.encodeHTML("&#38; ü"); // "&amp;&num;38&semi; &uuml;"
 
 // Decoding

--- a/src/decode-codepoint.ts
+++ b/src/decode-codepoint.ts
@@ -11,9 +11,10 @@ const c1: number[] = [
 ];
 
 /**
- * Replace the given code point with a replacement character if it is a
- * surrogate or is outside the valid range. Otherwise return the code
- * point unchanged.
+ * Replace the given code point with U+FFFD if it is NUL (0), a surrogate, or
+ * outside the valid Unicode range. Code points in the C1 controls range
+ * (128–159) are remapped to their Windows-1252 equivalents, following the
+ * HTML spec. All other code points are returned unchanged.
  * @param codePoint Unicode code point to convert.
  */
 export function replaceCodePoint(codePoint: number): number {

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -43,7 +43,7 @@ function isAlpha(code: number): boolean {
  *
  * Attribute values that aren't terminated properly aren't parsed, and shouldn't lead to a parser error.
  * See the example in https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
- * @param code Code point to decode.
+ * @param code Code point to check.
  */
 function isEntityInAttributeInvalidEnd(code: number): boolean {
     return code === CharCodes.EQUALS || isAlpha(code) || isNumber(code);
@@ -91,7 +91,7 @@ export class EntityDecoder {
     /**
      * The result of the entity.
      *
-     * Either the result index of a numeric entity, or the codepoint of a
+     * Either the result index of a named entity, or the codepoint of a
      * numeric entity.
      */
     private result = 0;
@@ -112,10 +112,11 @@ export class EntityDecoder {
         /**
          * The function that is called when a codepoint is decoded.
          *
-         * For multi-byte named entities, this will be called multiple times,
-         * with the second codepoint, and the same `consumed` value.
+         * For named entities that decode to multiple code points, this will
+         * be called multiple times, with the second codepoint, and the same
+         * `consumed` value.
          * @param codepoint The decoded codepoint.
-         * @param consumed The number of bytes consumed by the decoder.
+         * @param consumed The number of characters consumed by the decoder.
          */
         private readonly emitCodePoint: (cp: number, consumed: number) => void,
         /** An object that is used to produce errors. */

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -157,7 +157,7 @@ const numericReference = (cp: number) => `&#${cp};`;
  *
  * If a character has no equivalent entity, a numeric decimal reference
  * (eg. `&#252;`) will be used.
- * @param input Input string to encode or decode.
+ * @param input Input string to encode.
  */
 export function encodeHTML(input: string): string {
     return encodeHTMLTrieRe(HTML_BITSET, input);
@@ -169,7 +169,7 @@ export function encodeHTML(input: string): string {
  *
  * If a character has no equivalent entity, a numeric decimal reference
  * (eg. `&#252;`) will be used.
- * @param input Input string to encode or decode.
+ * @param input Input string to encode.
  */
 export function encodeNonAsciiHTML(input: string): string {
     return encodeHTMLTrieRe(XML_BITSET, input);

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -38,7 +38,7 @@ function isXmlEscapable(code: number): boolean {
  *
  * If a character has no equivalent entity, a numeric decimal reference
  * (eg. `&#252;`) will be used.
- * @param input Input string to encode or decode.
+ * @param input Input string to encode.
  */
 export function encodeXML(input: string): string {
     const { length } = input;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,8 @@ export interface DecodingOptions {
      * Decoding mode. If `Legacy`, will support legacy entities not terminated
      * with a semicolon (`;`).
      *
-     * Always `Strict` for XML. For HTML, set this to `true` if you are parsing
-     * an attribute value.
+     * Always `Strict` for XML. For HTML, set this to
+     * {@link DecodingMode.Attribute} if you are parsing an attribute value.
      * @default {@link DecodingMode.Legacy}
      */
     mode?: DecodingMode | undefined;


### PR DESCRIPTION
Fixes several factually incorrect pieces of documentation (JSDoc and readme). No code changes.

- `src/index.ts` — `DecodingOptions.mode`: said "set this to `true` if you are parsing an attribute value", but the field is a `DecodingMode` enum, not a boolean. Now references `DecodingMode.Attribute`.
- `readme.md` — usage example claimed `encodeXML("&#38; ü")` returns `"&amp;#38; &#xfc;"`; it actually returns `"&amp;#38; &#252;"` (decimal numeric references). Verified by running the example against the built package.
- `src/decode.ts` — `EntityDecoder.result` doc said "the result index of a numeric entity"; the stored index is for *named* entities (the codepoint is what's stored for numeric ones).
- `src/decode.ts` — `emitCodePoint` constructor param docs: `consumed` counts *characters*, not bytes, and the multiple-emission case applies to entities that decode to multiple code points ("multi-byte" was misleading).
- `src/decode.ts` — `isEntityInAttributeInvalidEnd`: `@param code` said "Code point to decode"; the code point is only checked.
- `src/decode-codepoint.ts` — `replaceCodePoint` doc claimed only surrogates/out-of-range values are replaced and everything else is returned unchanged; it also replaces NUL with U+FFFD and remaps C1 controls (128–159) to their Windows-1252 equivalents.
- `src/encode.ts` / `src/escape.ts` — `encodeHTML`, `encodeNonAsciiHTML`, and `encodeXML` described their input as "Input string to encode or decode"; these functions only encode.

Build, tests (311 passing), and lint are green.