### PR TITLE
test: keep unterminated strict named entities literal

### DIFF
--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -136,6 +136,22 @@ describe.each(implementations)("Decode test: %s", (_name, {
         expect(decodeHTML("&timesbar")).toBe("×bar");
     });
 
+    /*
+     * Strict named entities have no semicolon-less form. When the next
+     * character cannot continue the name, the reference must stay literal.
+     * npm 7.0.0–8.0.0 emitted an unrelated code point and ate the trailer
+     * (decodeHTML("&Xi$") === "Â"). See #2331.
+     */
+    it.each([
+        "&Xi$",
+        "&Chi)",
+        "&eta8",
+        "&Psi-",
+    ])("should not decode unterminated strict entity %s (#2331)", (input) => {
+        expect(decodeHTML(input)).toBe(input);
+        expect(decodeHTMLStrict(input)).toBe(input);
+    });
+
     it("should HTML decode legacy entities according to spec", () =>
         expect(decodeHTML("?&image_uri=1&ℑ=2&image=3")).toBe(
             "?&image_uri=1&ℑ=2&image=3",

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -139,7 +139,7 @@ describe.each(implementations)("Decode test: %s", (_name, {
     /*
      * Strict named entities have no semicolon-less form. When the next
      * character cannot continue the name, the reference must stay literal.
-     * npm 7.0.0–8.0.0 emitted an unrelated code point and ate the trailer
+     * npm 7.0.0 through 8.0.0 emitted an unrelated code point and ate the trailer
      * (decodeHTML("&Xi$") === "Â"). See #2331.
      */
     it.each([


### PR DESCRIPTION
Fixes #2331.

On npm 7.0.0 through 8.0.0, `decodeHTML("&Xi$")` returns `"Â"` and consumes the `$`. The same input is left literal on 6.0.1 and on current main.

These names have no semicolon-less legacy form. The tests lock that behavior in the sync decoder and both streaming chunk sizes so the next release does not ship the 8.0.0 decode again.