### PR TITLE
fix(decode): skip Windows-1252 C1 remap for XML numeric references

### DIFF
--- a/src/decode-codepoint.spec.ts
+++ b/src/decode-codepoint.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { replaceCodePoint, replaceCodePointXML } from "./decode-codepoint.js";
+
+describe("replaceCodePoint", () => {
+    it("should remap C1 controls to Windows-1252", () => {
+        expect(replaceCodePoint(0x80)).toBe(0x20_ac);
+        expect(replaceCodePoint(0x9a)).toBe(0x1_61);
+        expect(replaceCodePoint(0x81)).toBe(0x81);
+    });
+
+    it("should replace NUL, surrogates, and out-of-range values", () => {
+        expect(replaceCodePoint(0)).toBe(0xff_fd);
+        expect(replaceCodePoint(0xd8_00)).toBe(0xff_fd);
+        expect(replaceCodePoint(0x11_00_00)).toBe(0xff_fd);
+    });
+});
+
+describe("replaceCodePointXML", () => {
+    it("should leave C1 controls unchanged", () => {
+        expect(replaceCodePointXML(0x80)).toBe(0x80);
+        expect(replaceCodePointXML(0x9a)).toBe(0x9a);
+        expect(replaceCodePointXML(0x81)).toBe(0x81);
+    });
+
+    it("should still replace NUL, surrogates, and out-of-range values", () => {
+        expect(replaceCodePointXML(0)).toBe(0xff_fd);
+        expect(replaceCodePointXML(0xd8_00)).toBe(0xff_fd);
+        expect(replaceCodePointXML(0x11_00_00)).toBe(0xff_fd);
+    });
+});

--- a/src/decode-codepoint.ts
+++ b/src/decode-codepoint.ts
@@ -11,6 +11,18 @@ const c1: number[] = [
 ];
 
 /**
+ * True for NUL, UTF-16 surrogates, and values past U+10FFFF.
+ * @param codePoint Unicode code point to check.
+ */
+function isInvalidCodePoint(codePoint: number): boolean {
+    return (
+        codePoint === 0 ||
+        (codePoint >= 0xd8_00 && codePoint <= 0xdf_ff) ||
+        codePoint > 0x10_ff_ff
+    );
+}
+
+/**
  * Replace the given code point with U+FFFD if it is NUL (0), a surrogate, or
  * outside the valid Unicode range. Code points in the C1 controls range
  * (128–159) are remapped to their Windows-1252 equivalents, following the
@@ -18,11 +30,7 @@ const c1: number[] = [
  * @param codePoint Unicode code point to convert.
  */
 export function replaceCodePoint(codePoint: number): number {
-    if (
-        codePoint === 0 ||
-        (codePoint >= 0xd8_00 && codePoint <= 0xdf_ff) ||
-        codePoint > 0x10_ff_ff
-    ) {
+    if (isInvalidCodePoint(codePoint)) {
         return 0xff_fd;
     }
 
@@ -31,6 +39,17 @@ export function replaceCodePoint(codePoint: number): number {
     }
 
     return codePoint;
+}
+
+/**
+ * XML numeric character references are the referenced Unicode code point.
+ * Invalid values still become U+FFFD; the HTML Windows-1252 C1 remap is not
+ * applied.
+ * @see https://www.w3.org/TR/xml/#NT-CharRef
+ * @param codePoint Unicode code point to convert.
+ */
+export function replaceCodePointXML(codePoint: number): number {
+    return isInvalidCodePoint(codePoint) ? 0xff_fd : codePoint;
 }
 
 /**

--- a/src/decode-stream.spec.ts
+++ b/src/decode-stream.spec.ts
@@ -6,8 +6,6 @@ import {
     decodeHTML,
     decodeXML,
     EntityDecoder,
-    replaceCodePoint,
-    replaceCodePointXML,
 } from "./decode.js";
 import { htmlDecodeTree } from "./generated/decode-data-html.js";
 import { xmlDecodeTree } from "./generated/decode-data-xml.js";
@@ -324,45 +322,13 @@ describe("EntityDecoder Streaming", () => {
             expect(accepting.callback).toHaveBeenCalledWith(0xc1, 7);
         });
     });
-    it.each([
-        ["original", xmlDecodeTree],
-        ["copied", new Uint16Array(xmlDecodeTree)],
-    ] as const)(
-        "should preserve XML numeric references with the %s tree",
-        (_, tree) => {
-            for (const chunkSize of [Number.MAX_SAFE_INTEGER, 1]) {
-                for (const input of ["&#x80;", "&#128;"]) {
-                    expect(streamEntity(tree, input, chunkSize)).toEqual({
-                        output: "\u{80}",
-                        consumed: input.length,
-                    });
-                }
-            }
-        },
-    );
-
-    it("should use an explicit numeric replacement function for custom trees", () => {
+    it("should not remap C1 numeric references when using the XML tree", () => {
         const callback = vi.fn();
-        const decoder = new EntityDecoder(
-            new Uint16Array(),
-            callback,
-            undefined,
-            replaceCodePointXML,
-        );
+        const decoder = new EntityDecoder(xmlDecodeTree, callback);
+
+        decoder.startEntity(DecodingMode.Strict);
         expect(decoder.write("#x80;", 0)).toBe(6);
         expect(callback).toHaveBeenCalledWith(0x80, 6);
-    });
-
-    it("should allow HTML numeric replacement with XML named entities", () => {
-        const callback = vi.fn();
-        const decoder = new EntityDecoder(
-            xmlDecodeTree,
-            callback,
-            undefined,
-            replaceCodePoint,
-        );
-        expect(decoder.write("#x80;", 0)).toBe(6);
-        expect(callback).toHaveBeenCalledWith(0x20_ac, 6);
     });
 
     it("should remap C1 numeric references when using the HTML tree", () => {

--- a/src/decode-stream.spec.ts
+++ b/src/decode-stream.spec.ts
@@ -6,6 +6,8 @@ import {
     decodeHTML,
     decodeXML,
     EntityDecoder,
+    replaceCodePoint,
+    replaceCodePointXML,
 } from "./decode.js";
 import { htmlDecodeTree } from "./generated/decode-data-html.js";
 import { xmlDecodeTree } from "./generated/decode-data-xml.js";
@@ -322,13 +324,45 @@ describe("EntityDecoder Streaming", () => {
             expect(accepting.callback).toHaveBeenCalledWith(0xc1, 7);
         });
     });
-    it("should not remap C1 numeric references when using the XML tree", () => {
-        const callback = vi.fn();
-        const decoder = new EntityDecoder(xmlDecodeTree, callback);
+    it.each([
+        ["original", xmlDecodeTree],
+        ["copied", new Uint16Array(xmlDecodeTree)],
+    ] as const)(
+        "should preserve XML numeric references with the %s tree",
+        (_, tree) => {
+            for (const chunkSize of [Number.MAX_SAFE_INTEGER, 1]) {
+                for (const input of ["&#x80;", "&#128;"]) {
+                    expect(streamEntity(tree, input, chunkSize)).toEqual({
+                        output: "\u{80}",
+                        consumed: input.length,
+                    });
+                }
+            }
+        },
+    );
 
-        decoder.startEntity(DecodingMode.Strict);
+    it("should use an explicit numeric replacement function for custom trees", () => {
+        const callback = vi.fn();
+        const decoder = new EntityDecoder(
+            new Uint16Array(),
+            callback,
+            undefined,
+            replaceCodePointXML,
+        );
         expect(decoder.write("#x80;", 0)).toBe(6);
         expect(callback).toHaveBeenCalledWith(0x80, 6);
+    });
+
+    it("should allow HTML numeric replacement with XML named entities", () => {
+        const callback = vi.fn();
+        const decoder = new EntityDecoder(
+            xmlDecodeTree,
+            callback,
+            undefined,
+            replaceCodePoint,
+        );
+        expect(decoder.write("#x80;", 0)).toBe(6);
+        expect(callback).toHaveBeenCalledWith(0x20_ac, 6);
     });
 
     it("should remap C1 numeric references when using the HTML tree", () => {

--- a/src/decode-stream.spec.ts
+++ b/src/decode-stream.spec.ts
@@ -322,4 +322,21 @@ describe("EntityDecoder Streaming", () => {
             expect(accepting.callback).toHaveBeenCalledWith(0xc1, 7);
         });
     });
+    it("should not remap C1 numeric references when using the XML tree", () => {
+        const callback = vi.fn();
+        const decoder = new EntityDecoder(xmlDecodeTree, callback);
+
+        decoder.startEntity(DecodingMode.Strict);
+        expect(decoder.write("#x80;", 0)).toBe(6);
+        expect(callback).toHaveBeenCalledWith(0x80, 6);
+    });
+
+    it("should remap C1 numeric references when using the HTML tree", () => {
+        const callback = vi.fn();
+        const decoder = new EntityDecoder(htmlDecodeTree, callback);
+
+        decoder.startEntity(DecodingMode.Strict);
+        expect(decoder.write("#x80;", 0)).toBe(6);
+        expect(callback).toHaveBeenCalledWith(0x20_ac, 6);
+    });
 });

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -332,6 +332,25 @@ describe.each(implementations)(
             }
         });
 
+        describe("numeric C1 controls", () => {
+            it("should not remap C1 references in XML", () => {
+                expect(decodeXML("&#x80;")).toBe("\u{80}");
+                expect(decodeXML("&#128;")).toBe("\u{80}");
+                expect(decodeXML("&#x9A;")).toBe("\u{9A}");
+                expect(decodeXML("&#x9a;")).toBe("\u{9A}");
+            });
+
+            it("should remap C1 references in HTML to Windows-1252", () => {
+                expect(decodeHTML("&#x80;")).toBe("\u{20AC}");
+                expect(decodeHTML("&#128;")).toBe("\u{20AC}");
+                expect(decodeHTML("&#x9A;")).toBe("\u{161}");
+            });
+
+            it("should still replace NUL and out-of-range values in XML", () => {
+                expect(decodeXML("&#0;")).toBe("\u{FFFD}");
+                expect(decodeXML("&#x110000;")).toBe("\u{FFFD}");
+            });
+        });
         describe("non-entities with legacy-like prefixes stay literal", () => {
             /*
              * A strict-only name without a semicolon and without a legacy

--- a/src/decode.spec.ts
+++ b/src/decode.spec.ts
@@ -332,7 +332,7 @@ describe.each(implementations)(
             }
         });
 
-        describe("numeric C1 controls", () => {
+        describe("numeric reference replacement", () => {
             it("should not remap C1 references in XML", () => {
                 expect(decodeXML("&#x80;")).toBe("\u{80}");
                 expect(decodeXML("&#128;")).toBe("\u{80}");
@@ -346,11 +346,33 @@ describe.each(implementations)(
                 expect(decodeHTML("&#x9A;")).toBe("\u{161}");
             });
 
-            it("should still replace NUL and out-of-range values in XML", () => {
-                expect(decodeXML("&#0;")).toBe("\u{FFFD}");
-                expect(decodeXML("&#x110000;")).toBe("\u{FFFD}");
+            it("should decode XML numeric references across BMP and replacement boundaries", () => {
+                const cases = [
+                    [0, 0xff_fd],
+                    [1, 1],
+                    [0x7f, 0x7f],
+                    [0x80, 0x80],
+                    [0x9f, 0x9f],
+                    [0xa0, 0xa0],
+                    [0xd7_ff, 0xd7_ff],
+                    [0xd8_00, 0xff_fd],
+                    [0xdf_ff, 0xff_fd],
+                    [0xe0_00, 0xe0_00],
+                    [0xff_ff, 0xff_ff],
+                    [0x1_00_00, 0x1_00_00],
+                    [0x10_ff_ff, 0x10_ff_ff],
+                    [0x11_00_00, 0xff_fd],
+                ];
+                for (const [codePoint, replacement] of cases) {
+                    const expected = String.fromCodePoint(replacement);
+                    expect(decodeXML(`&#${codePoint};`)).toBe(expected);
+                    expect(decodeXML(`&#x${codePoint.toString(16)};`)).toBe(
+                        expected,
+                    );
+                }
             });
         });
+
         describe("non-entities with legacy-like prefixes stay literal", () => {
             /*
              * A strict-only name without a semicolon and without a legacy

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -1,5 +1,10 @@
-import { codePointToString, replaceCodePoint } from "./decode-codepoint.js";
+import {
+    codePointToString,
+    replaceCodePoint,
+    replaceCodePointXML,
+} from "./decode-codepoint.js";
 import { htmlDecodeTree } from "./generated/decode-data-html.js";
+import { xmlDecodeTree } from "./generated/decode-data-xml.js";
 import { BinTrieFlags } from "./internal/bin-trie-flags.js";
 
 const enum CharCodes {
@@ -150,7 +155,6 @@ export class EntityDecoder {
 
     constructor(
         /** The tree used to decode entities. */
-        // biome-ignore lint/correctness/noUnusedPrivateClassMembers: False positive
         private readonly decodeTree: Uint16Array,
         /**
          * The function that is called when a codepoint is decoded.
@@ -341,7 +345,12 @@ export class EntityDecoder {
             return 0;
         }
 
-        this.emitCodePoint(replaceCodePoint(this.result), this.consumed);
+        this.emitCodePoint(
+            (this.decodeTree === xmlDecodeTree
+                ? replaceCodePointXML
+                : replaceCodePoint)(this.result),
+            this.consumed,
+        );
 
         if (this.errors) {
             if (lastCp !== CharCodes.SEMI) {
@@ -1268,7 +1277,9 @@ export function decodeXML(xmlString: string): string {
             ) {
                 consumed = 0;
             } else {
-                value = codePointToString(packed & CODE_POINT_MASK);
+                value = String.fromCodePoint(
+                    replaceCodePointXML(packed & CODE_POINT_MASK),
+                );
             }
         } else {
             /* eslint-disable unicorn/no-break-in-nested-loop -- Keep XML name dispatch inline with the decode loop. */
@@ -1345,7 +1356,10 @@ export function decodeXML(xmlString: string): string {
     return result + xmlString.slice(lastIndex);
 }
 
-export { replaceCodePoint } from "./decode-codepoint.js";
+export {
+    replaceCodePoint,
+    replaceCodePointXML,
+} from "./decode-codepoint.js";
 // Re-export for use by eg. htmlparser2
 export { htmlDecodeTree } from "./generated/decode-data-html.js";
 export { xmlDecodeTree } from "./generated/decode-data-xml.js";

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -154,8 +154,7 @@ export class EntityDecoder {
     private runConsumed = 0;
 
     constructor(
-        /** The tree used to decode entities. */
-        // biome-ignore lint/correctness/noUnusedPrivateClassMembers: False positive (read via destructuring)
+        /** The predefined HTML or XML decode tree. */
         private readonly decodeTree: Uint16Array,
         /**
          * The function that is called when a codepoint is decoded.
@@ -169,17 +168,6 @@ export class EntityDecoder {
         private readonly emitCodePoint: (cp: number, consumed: number) => void,
         /** An object that is used to produce errors. */
         private readonly errors?: EntityErrorProducer | undefined,
-        /**
-         * Converts numeric reference values to code points. Defaults to XML
-         * replacement for XML tree data, including copies, and HTML otherwise.
-         * Pass a replacement function explicitly for custom trees.
-         */
-        private readonly replaceNumericCodePoint: typeof replaceCodePoint = decodeTree ===
-            xmlDecodeTree ||
-        (decodeTree.length === xmlDecodeTree.length &&
-            decodeTree.every((value, index) => value === xmlDecodeTree[index]))
-            ? replaceCodePointXML
-            : replaceCodePoint,
     ) {}
 
     /**
@@ -358,7 +346,9 @@ export class EntityDecoder {
         }
 
         this.emitCodePoint(
-            this.replaceNumericCodePoint(this.result),
+            (this.decodeTree === xmlDecodeTree
+                ? replaceCodePointXML
+                : replaceCodePoint)(this.result),
             this.consumed,
         );
 
@@ -1287,9 +1277,12 @@ export function decodeXML(xmlString: string): string {
             ) {
                 consumed = 0;
             } else {
-                value = String.fromCodePoint(
-                    replaceCodePointXML(packed & CODE_POINT_MASK),
-                );
+                const codePoint = packed & CODE_POINT_MASK;
+                // Nonzero BMP values below the surrogate range need no replacement.
+                value =
+                    (codePoint - 1) >>> 0 < 0xd7_ff
+                        ? String.fromCharCode(codePoint)
+                        : String.fromCodePoint(replaceCodePointXML(codePoint));
             }
         } else {
             /* eslint-disable unicorn/no-break-in-nested-loop -- Keep XML name dispatch inline with the decode loop. */

--- a/src/decode.ts
+++ b/src/decode.ts
@@ -155,6 +155,7 @@ export class EntityDecoder {
 
     constructor(
         /** The tree used to decode entities. */
+        // biome-ignore lint/correctness/noUnusedPrivateClassMembers: False positive (read via destructuring)
         private readonly decodeTree: Uint16Array,
         /**
          * The function that is called when a codepoint is decoded.
@@ -168,6 +169,17 @@ export class EntityDecoder {
         private readonly emitCodePoint: (cp: number, consumed: number) => void,
         /** An object that is used to produce errors. */
         private readonly errors?: EntityErrorProducer | undefined,
+        /**
+         * Converts numeric reference values to code points. Defaults to XML
+         * replacement for XML tree data, including copies, and HTML otherwise.
+         * Pass a replacement function explicitly for custom trees.
+         */
+        private readonly replaceNumericCodePoint: typeof replaceCodePoint = decodeTree ===
+            xmlDecodeTree ||
+        (decodeTree.length === xmlDecodeTree.length &&
+            decodeTree.every((value, index) => value === xmlDecodeTree[index]))
+            ? replaceCodePointXML
+            : replaceCodePoint,
     ) {}
 
     /**
@@ -346,9 +358,7 @@ export class EntityDecoder {
         }
 
         this.emitCodePoint(
-            (this.decodeTree === xmlDecodeTree
-                ? replaceCodePointXML
-                : replaceCodePoint)(this.result),
+            this.replaceNumericCodePoint(this.result),
             this.consumed,
         );
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -87,7 +87,7 @@ const astral = [
 ];
 
 const astralSpecial = [
-    ["80", "\u{20AC}"],
+    ["80", "\u{80}"],
     ["110000", "\u{FFFD}"],
 ];
 
@@ -107,6 +107,10 @@ describe("Astral entities", () => {
     it.each(astralSpecial)(String.raw`should decode special \u%s`, (c, value) =>
         expect(entities.decode(`&#x${c};`)).toBe(value),
     );
+});
+
+it("should apply the HTML Windows-1252 C1 remap", () => {
+    expect(entities.decodeHTML("&#x80;")).toBe("\u{20AC}");
 });
 
 describe("Escape", () => {


### PR DESCRIPTION
fix(decode): skip Windows-1252 C1 remap for XML numeric references

Fixes #2320

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/fb55/entities/pull/2347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - XML numeric character references now preserve C1 control characters, such as `&`#x80`;`, instead of converting them to Windows-1252 characters.
  - HTML numeric character references continue to map C1 controls to their corresponding Windows-1252 characters, such as converting `&`#x80`;` to the euro sign.
  - Invalid numeric character references, including NUL, surrogate, and out-of-range values, continue to decode as U+FFFD.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->